### PR TITLE
Defining version for pip 1.4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         'versiontools >= 1.4',
     ],
     install_requires = [
-        'phonenumbers',
+        'phonenumbers >= 5.9b1',
     ],
     long_description=open('README.rst').read(),
     author='Stefan Foulis',


### PR DESCRIPTION
PIP 1.4+ treats version numbers which aren’t compliant with PEP426 as pre-releases, and won’t use them… `phonenumbers` uses such version numbers.

Setting a similarly non-compliant version gets around this (feel free to propose an alternative version to compare with).
