### PR TITLE
Use phonenumberslite as a dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,10 @@ django-phonenumber-field
 ========================
 
 
-A international phone number field for django that uses http://pypi.python.org/pypi/phonenumbers for validation .
+A international phone number field for django that uses http://pypi.python.org/pypi/phonenumbers for validation.
+
+*Note:* This package will by default install `phonenumberslite` if no
+ phonenumbers package has been installed already.
 
 Installation
 ============
@@ -28,7 +31,6 @@ PhoneNumberField will always represent the number as a string of an internationa
 `+41524204242`.
 
 The object returned is not just a plain String. It is a PhoneNumber object. Currently it is necessary to always use
-the international format when entering data. 
+the international format when entering data.
 
 Future versions of django-phonenumber-field may provide custom special widgets that support more custom formatting.
-

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup, find_packages
+import pkgutil
+
+phonenumbers_installed = filter(lambda p: p[1] == 'phonenumbers', 
+                                pkgutil.iter_modules())
 
 setup(
     name="django-phonenumber-field",
@@ -11,7 +15,7 @@ setup(
         'versiontools >= 1.4',
     ],
     install_requires = [
-        'phonenumbers',
+        'phonenumberslite>=6.0.0a' if not phonenumbers_installed else '',
     ],
     long_description=open('README.rst').read(),
     author='Stefan Foulis',


### PR DESCRIPTION
The `phonenumbers` package has created a smaller packade aimed for simpler
use cases, like this module. So in case the user doesn't have any package
`phonenumbers` installed at all then try to install `phonenumberslite`.

Since both `phonenumbers` and `phonenumberslite` installs into the same
folder this will only add the dependency if there is no package installed
prior, and if someone already got the full package that will also play ball.