### PR TITLE
allow save null values to phonenumber field

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -54,11 +54,12 @@ class PhoneNumberField(models.Field):
 
     def get_prep_value(self, value):
         "Returns field's value prepared for saving into a database."
-        if value is None:
-            if not self.blank:
+        if not value:
+            if self.has_default():
                 return to_python(self.default)
-            elif self.blank:
-                return to_python(self.default) or ''
+            if not self.null:
+                return ''
+            return value
 
         value = to_python(value)
         if isinstance(value, string_types):

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-phonenumber-field",
-    version = ":versiontools:phonenumber_field:",
+    version=":versiontools:phonenumber_field:",
     url='http://github.com/stefanfoulis/django-phonenumber-field',
     license='BSD',
     platforms=['OS Independent'],
     description="An international phone number field for django models.",
-    setup_requires = [
+    setup_requires=[
         'versiontools >= 1.4',
     ],
-    install_requires = [
+    install_requires=[
         'phonenumbers >= 5.9b1',
     ],
     long_description=open('README.rst').read(),

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -1,13 +1,22 @@
 from django.db import models
 from phonenumber_field.modelfields import PhoneNumberField
 
-# Create your models here.
-
 
 class TestModel(models.Model):
     name = models.CharField(max_length=255, blank=True, default='')
     phone = PhoneNumberField()
-    
+
+
 class TestModelBlankPhone(models.Model):
     name = models.CharField(max_length=255, blank=True, default='')
     phone = PhoneNumberField(blank=True)
+
+
+class TestModelDefaultPhone(models.Model):
+    name = models.CharField(max_length=255, blank=True, default='')
+    phone = PhoneNumberField(default='+41 52 424 2424')
+
+
+class TestModelBlankAndUniquePhone(models.Model):
+    name = models.CharField(max_length=255, blank=True, default='')
+    phone = PhoneNumberField(blank=True, null=True, unique=True)

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -4,6 +4,8 @@ when you run "manage.py test".
 
 Replace this with more appropriate tests for your application.
 """
+from django.db import transaction
+from django.db.utils import IntegrityError
 
 from django.test import TestCase
 
@@ -24,10 +26,31 @@ class PhonenumerFieldAppTest(TestCase):
         
     def test_save_blank_phone_to_database(self):
         from testapp.models import TestModelBlankPhone
-        from phonenumber_field.phonenumber import PhoneNumber
         tm = TestModelBlankPhone()
         tm.save()
         
         pk = tm.id
         tm = TestModelBlankPhone.objects.get(pk=pk)
         self.assertIsNone(tm.phone)
+
+    def test_default(self):
+        from testapp.models import TestModelDefaultPhone
+        tm = TestModelDefaultPhone.objects.create()
+        self.assertEqual(str(tm.phone), '+41524242424')
+
+    def test_save_blank_or_unique(self):
+        from testapp.models import TestModelBlankAndUniquePhone
+
+        tm_nullable1 = TestModelBlankAndUniquePhone.objects.create()
+        self.assertIsNone(tm_nullable1.phone)
+        tm_nullable2 = TestModelBlankAndUniquePhone.objects.create()
+        self.assertIsNone(tm_nullable2.phone)
+
+        tm_unique = TestModelBlankAndUniquePhone.objects.create(phone='+41 52 424 2424')
+        self.assertEqual(str(tm_unique.phone), '+41524242424')
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                TestModelBlankAndUniquePhone.objects.create(phone='+41524242424')
+
+        self.assertEqual(TestModelBlankAndUniquePhone.objects.count(), 3)
+

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -4,7 +4,10 @@ when you run "manage.py test".
 
 Replace this with more appropriate tests for your application.
 """
-from django.db import transaction
+try:
+    from django.db.transaction import atomic
+except ImportError:
+    from django.db.transaction import commit_on_success as atomic
 from django.db.utils import IntegrityError
 
 from django.test import TestCase
@@ -49,7 +52,7 @@ class PhonenumerFieldAppTest(TestCase):
         tm_unique = TestModelBlankAndUniquePhone.objects.create(phone='+41 52 424 2424')
         self.assertEqual(str(tm_unique.phone), '+41524242424')
         with self.assertRaises(IntegrityError):
-            with transaction.atomic():
+            with atomic():
                 TestModelBlankAndUniquePhone.objects.create(phone='+41524242424')
 
         self.assertEqual(TestModelBlankAndUniquePhone.objects.count(), 3)


### PR DESCRIPTION
Hi!

This PR fixes regression introduced in v0.6. 
In my model I want to phone be empty and unique if it's not empty. Since last changes in https://github.com/stefanfoulis/django-phonenumber-field/commit/1c7b803121145098d85bb6ab547657ab15519862 all emptye values (None and '') saves as empty strings, but database interpret empty strings as NOT NULL values and raises IntegrityError.

Old tests not broken and new added.

BTW, thanks for great app! Very useful for me!