### PR TITLE
Add PHONENUMBER_SERIALIZE_FORMAT setting

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -2,6 +2,7 @@
 from django.core import validators
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 from phonenumber_field.validators import validate_international_phonenumber
 from phonenumber_field import formfields
 from phonenumber_field.phonenumber import PhoneNumber, to_python, string_types
@@ -64,7 +65,11 @@ class PhoneNumberField(models.Field):
         if isinstance(value, string_types):
             # it is an invalid phone number
             return value
-        return value.as_e164
+        serialize_format = PhoneNumber.format_map.get(
+            getattr(settings, 'PHONENUMBER_SERIALIZE_FORMAT', 'E164'),
+            PhoneNumber.format_map['E164']
+        )
+        return value.format_as(serialize_format)
 
     def contribute_to_class(self, cls, name):
         super(PhoneNumberField, self).contribute_to_class(cls, name)

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -6,6 +6,7 @@ Replace this with more appropriate tests for your application.
 """
 
 from django.test import TestCase
+from django.conf import settings
 
 
 class PhonenumerFieldAppTest(TestCase):
@@ -21,13 +22,40 @@ class PhonenumerFieldAppTest(TestCase):
         tm = TestModel.objects.get(pk=pk)
         self.assertTrue(isinstance(tm.phone, PhoneNumber))
         self.assertEqual(str(tm.phone), '+41524242424')
-        
+
     def test_save_blank_phone_to_database(self):
         from testapp.models import TestModelBlankPhone
         from phonenumber_field.phonenumber import PhoneNumber
         tm = TestModelBlankPhone()
         tm.save()
-        
+
         pk = tm.id
         tm = TestModelBlankPhone.objects.get(pk=pk)
         self.assertIsNone(tm.phone)
+
+    def test_settings_format(self):
+        from testapp.models import TestModel
+        settings.PHONENUMBER_DEFAULT_REGION = 'US'
+        settings.PHONENUMBER_DEFAULT_FORMAT = 'NATIONAL'
+        tm = TestModel()
+        tm.phone = '(234) 567-8901'
+        tm.full_clean()
+        tm.save()
+        pk = tm.id
+        tm = TestModel.objects.get(pk=pk)
+        self.assertEqual(str(tm.phone), '(234) 567-8901')
+
+    def test_settings_serialize(self):
+        # The E164 serialization format doesn't include extensions. By testing that our extension
+        # is still there, we test that the serialization setting actually works.
+        from testapp.models import TestModel
+        settings.PHONENUMBER_DEFAULT_REGION = 'US'
+        settings.PHONENUMBER_DEFAULT_FORMAT = 'NATIONAL'
+        settings.PHONENUMBER_SERIALIZE_FORMAT = 'NATIONAL'
+        tm = TestModel()
+        tm.phone = '(234) 567-8901 ext. 123'
+        tm.full_clean()
+        tm.save()
+        pk = tm.id
+        tm = TestModel.objects.get(pk=pk)
+        self.assertEqual(str(tm.phone), '(234) 567-8901 ext. 123')


### PR DESCRIPTION
The E164 format doesn't include extensions and if someone wants to keep
this information, he has to either create a new field or change the
serialization format.

This commit allows us to change our serialization format through the
PHONENUMBER_SERIALIZE_FORMAT setting.