### PR TITLE
quick and dirty fix for Django 1.7 migrations bug

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -60,7 +60,9 @@ class PhoneNumberField(models.Field):
             elif self.blank:
                 return to_python(self.default) or ''
 
-        value = to_python(value)
+        if value != '':
+            value = to_python(value)
+        
         if isinstance(value, string_types):
             # it is an invalid phone number
             return value


### PR DESCRIPTION
The function check if value can be None at the beginning but if it is an empty string to_python will return None and get_prep_value will try to execute value.as_e164 with value as None type.

This is the traceback I got:
```
Running migrations:
  Applying accounts.0010_auto_20140808_1433...Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/core/management/base.py", line 337, in execute
    output = self.handle(*args, **options)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/core/management/commands/migrate.py", line 160, in handle
    executor.migrate(targets, plan, fake=options.get("fake", False))
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/migrations/executor.py", line 63, in migrate
    self.apply_migration(migration, fake=fake)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/migrations/executor.py", line 97, in apply_migration
    migration.apply(project_state, schema_editor)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/migrations/migration.py", line 107, in apply
    operation.database_forwards(self.app_label, schema_editor, project_state, new_state)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/migrations/operations/fields.py", line 131, in database_forwards
    schema_editor.alter_field(from_model, from_field, to_field)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/backends/schema.py", line 509, in alter_field
    self._alter_field(model, old_field, new_field, old_type, new_type, old_db_params, new_db_params, strict)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/backends/schema.py", line 610, in _alter_field
    new_default = self.effective_default(new_field)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/backends/schema.py", line 183, in effective_default
    default = field.get_db_prep_save(default, self.connection)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/models/fields/__init__.py", line 627, in get_db_prep_save
    prepared=False)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/django/db/models/fields/__init__.py", line 619, in get_db_prep_value
    value = self.get_prep_value(value)
  File "/home/esistgut/apps/python_virtualenvs/iteritaly/lib/python3.4/site-packages/phonenumber_field/modelfields.py", line 67, in get_prep_value
    return value.as_e164
AttributeError: 'NoneType' object has no attribute 'as_e164'
```