### PR TITLE
Let python-phonenumbers compare PhoneNumber instances

### DIFF
--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -75,12 +75,6 @@ class PhoneNumber(phonenumbers.phonenumber.PhoneNumber):
     def __len__(self):
         return len(self.__unicode__())
 
-    def __eq__(self, other):
-        if type(other) == PhoneNumber:
-            return self.as_e164 == other.as_e164
-        else:
-            return super(PhoneNumber, self).__eq__(other)
-
 
 def to_python(value):
     if value in validators.EMPTY_VALUES:  # None or ''

--- a/phonenumber_field/tests.py
+++ b/phonenumber_field/tests.py
@@ -3,6 +3,8 @@
 from django.test.testcases import TestCase
 from django.db import models
 
+from phonenumbers import is_number_match, MatchType
+
 from phonenumber_field.modelfields import PhoneNumberField
 from phonenumber_field.phonenumber import PhoneNumber
 from phonenumber_field.validators import to_python
@@ -52,7 +54,8 @@ class PhoneNumberFieldTestCase(TestCase):
             MandatoryPhoneNumber.objects.create(
                 phone_number=number_string).phone_number
             for number_string in self.equal_number_strings]
-        self.assertTrue(all(n == numbers[0] for n in numbers))
+        self.assertTrue(all(is_number_match(n, numbers[0]) == MatchType.EXACT_MATCH
+                        for n in numbers))
 
     def test_field_returns_correct_type(self):
         model = OptionalPhoneNumber()


### PR DESCRIPTION
in `phonenumber.py`, the overridden `__eq__` converts the number to e_164 before the comparison:
```python
def __eq__(self, other):
    if type(other) == PhoneNumber:
        return self.as_e164 == other.as_e164
    else:
        return super(PhoneNumber, self).__eq__(other)
```
It seems that the e_164 conversion does not include the extension, and it causes a comparison of two PhoneNumbers to be erroneous when only the extension is divergent. For example:
```python
> other
PhoneNumber(country_code=1, national_number=8005551234, extension='2', italian_leading_zero=None, number_of_leading_zeros=None, country_code_source=20, preferred_domestic_carrier_code='')
> self
PhoneNumber(country_code=1, national_number=8005551234, extension=None, italian_leading_zero=None, number_of_leading_zeros=None, country_code_source=20, preferred_domestic_carrier_code='')
> other == self
True
```
In my opinion, `django-phonenumber-field` should not be involved in the comparison, and should delegate all operations that involve phone number logic to `python-phonenumbers`.

