### PR TITLE
Fixing a minor bug.

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -48,4 +48,5 @@ class PhoneNumberPrefixWidget(MultiWidget):
 
     def value_from_datadict(self, data, files, name):
         values = super(PhoneNumberPrefixWidget, self).value_from_datadict(data, files, name)
-        return '%s.%s' % tuple(values)
+        if '' not in values:
+            return '%s.%s' % tuple(values)


### PR DESCRIPTION
When using PhoneNumberPrefixWidget and leaving the field empty, it doesn't save a '.' string anymore.
Also, if the prefix select or the textfield is empty, it will not save the field.