### PR TITLE
Fix: 'PhoneNumber' object has no attribute 'split'

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -43,7 +43,7 @@ class PhoneNumberPrefixWidget(MultiWidget):
 
     def decompress(self, value):
         if value:
-            return value.split('.')
+            return ['+{%d}' % value.country_code, value.national_number]
         return [None, None]
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
Fix: 'PhoneNumber' object has no attribute 'split'
