### PR TITLE
Support python 3.0 by revoming the u literal

### DIFF
--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 from django.utils.translation import ugettext_lazy as _
 from django.forms.fields import CharField
 from django.core.exceptions import ValidationError
@@ -8,7 +11,7 @@ from phonenumber_field.phonenumber import to_python
 
 class PhoneNumberField(CharField):
     default_error_messages = {
-        'invalid': _(u'Enter a valid phone number.'),
+        'invalid': _('Enter a valid phone number.'),
     }
     default_validators = [validate_international_phonenumber]
 

--- a/phonenumber_field/validators.py
+++ b/phonenumber_field/validators.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from phonenumber_field.phonenumber import to_python
@@ -8,4 +10,4 @@ from phonenumber_field.phonenumber import to_python
 def validate_international_phonenumber(value):
     phone_number = to_python(value)
     if phone_number and not phone_number.is_valid():
-        raise ValidationError(_(u'The phone number entered is not valid.'))
+        raise ValidationError(_('The phone number entered is not valid.'))


### PR DESCRIPTION
Hi,

Please accept this change for python 3. The u prefix causes syntax errors so this is replaced by import unicode_literals for equivalent functionality.

Thanks,

Logan
