### PR TITLE
Support saving phone numbers with extension in rfc3966 format

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -40,11 +40,15 @@ class PhoneNumberField(models.Field):
     attr_class = PhoneNumber
     descriptor_class = PhoneNumberDescriptor
     default_validators = [validate_international_phonenumber]
+    writing_formats = ['e164','rfc3966']
 
     description = _("Phone number")
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = kwargs.get('max_length', 128)
+        self.number_format = kwargs.pop('number_format', 'e164')
+        if not self.number_format in self.writing_formats:
+            raise NotImplementedError('Formats other than `e164` or `rfc3966` are not implemented')
         super(PhoneNumberField, self).__init__(*args, **kwargs)
         self.validators.append(validators.MaxLengthValidator(self.max_length))
 
@@ -63,6 +67,8 @@ class PhoneNumberField(models.Field):
         if isinstance(value, string_types):
             # it is an invalid phone number
             return value
+        if self.number_format == 'rfc3966':
+            return value.as_rfc3966
         return value.as_e164
 
     def contribute_to_class(self, cls, name):

--- a/phonenumber_field/tests.py
+++ b/phonenumber_field/tests.py
@@ -33,6 +33,7 @@ class PhoneNumberFieldTestCase(TestCase):
         ('DE', '0176/96842671'),
     ]
     invalid_numbers = ['+44 113 892111', ]
+    number_with_ext = '+86 0451 8450 2510 x231'
 
     def test_valid_numbers_are_valid(self):
         numbers = [PhoneNumber.from_string(number_string)
@@ -71,3 +72,11 @@ class PhoneNumberFieldTestCase(TestCase):
         # https://github.com/stefanfoulis/django-phonenumber-field/issues/11
         phone = to_python(42)
         self.assertEqual(phone, None)
+
+    def test_can_store_as_rfc3966(self):
+        rfc_phone_number_field = PhoneNumberField(blank=True, default='',
+                                                  number_format='rfc3966')
+        rfc_string = PhoneNumber.from_string(self.number_with_ext).as_rfc3966
+        self.assertEqual(
+            rfc_phone_number_field.get_prep_value(self.number_with_ext),
+            rfc_string)

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -7,7 +7,11 @@ from phonenumber_field.modelfields import PhoneNumberField
 class TestModel(models.Model):
     name = models.CharField(max_length=255, blank=True, default='')
     phone = PhoneNumberField()
-    
+
 class TestModelBlankPhone(models.Model):
     name = models.CharField(max_length=255, blank=True, default='')
     phone = PhoneNumberField(blank=True)
+
+class TestModelRfc(models.Model):
+    name = models.CharField(max_length=255, blank=True, default='')
+    phone = PhoneNumberField(number_format='rfc3966')

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -21,13 +21,27 @@ class PhonenumerFieldAppTest(TestCase):
         tm = TestModel.objects.get(pk=pk)
         self.assertTrue(isinstance(tm.phone, PhoneNumber))
         self.assertEqual(str(tm.phone), '+41524242424')
-        
+
     def test_save_blank_phone_to_database(self):
         from testapp.models import TestModelBlankPhone
         from phonenumber_field.phonenumber import PhoneNumber
         tm = TestModelBlankPhone()
         tm.save()
-        
+
         pk = tm.id
         tm = TestModelBlankPhone.objects.get(pk=pk)
         self.assertIsNone(tm.phone)
+
+    def test_save_phone_ext_to_database_with_rfc(self):
+        from testapp.models import TestModelRfc
+        from phonenumber_field.phonenumber import PhoneNumber
+        tm = TestModelRfc()
+        tm.phone = '+86 0451 8450 2510 x231'
+        tm.full_clean()
+        tm.save()
+        pk = tm.id
+
+        tm = TestModelRfc.objects.get(pk=pk)
+        self.assertTrue(isinstance(tm.phone, PhoneNumber))
+        self.assertEqual(tm.phone.extension, '231')
+        self.assertEqual(tm.phone.as_international, '+86 451 8450 2510 ext. 231')


### PR DESCRIPTION
Hi, I had run into a problem that extensions were not stored in database properly. In the proposed pull request, a new argument `number_format` supporting both  `e1641` and `rfc3966` was added to address it.

Currently, it service well for me. But I am not familiar with phone number formats. 

Any ideas? THX