### PR TITLE
convert language to locale

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -17,7 +17,7 @@ class PhonePrefixSelect(Select):
 
     def __init__(self, initial=None):
         choices = [('', '---------')]
-        locale = Locale(translation.get_language())
+        locale = Locale(translation.to_locale(translation.get_language()))
         for prefix, values in _COUNTRY_CODE_TO_REGION_CODE.iteritems():
             prefix = '+%d' % prefix
             if initial and initial in values:


### PR DESCRIPTION
Locale takes a properly formated locale string as parameter (eg: en_US), using language is wrong (although it works sometimes).

Note: had to change my repository's history to #65 was closed automatically. 