### PR TITLE
Fix field validation failing on no number provided by user

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -56,4 +56,9 @@ class PhoneNumberPrefixWidget(MultiWidget):
     def value_from_datadict(self, data, files, name):
         values = super(PhoneNumberPrefixWidget, self).value_from_datadict(
             data, files, name)
+
+        # Check for both fields empty
+        if not any(values):
+            return None
+
         return '%s.%s' % tuple(values)


### PR DESCRIPTION
Validation in `PhoneNumberField.to_python` fails when number is not provided (even if it is not required) because `PhoneNumberPrefixWidget.value_from_datadict` returns `r'.'`.
This fix makes it return `None` if user hasn't selected anything.
When field is required everything works as before (just fails on "Field is required" instead)

Someone might want to make some tests against this case, i don't really feel like it right now... :P