### PR TITLE
Return value based on empty type

### DIFF
--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -78,7 +78,7 @@ class PhoneNumber(phonenumbers.phonenumber.PhoneNumber):
 
 def to_python(value):
     if value in validators.EMPTY_VALUES:  # None or ''
-        phone_number = None
+        phone_number = value
     elif value and isinstance(value, string_types):
         try:
             phone_number = PhoneNumber.from_string(phone_number=value)

--- a/phonenumber_field/tests.py
+++ b/phonenumber_field/tests.py
@@ -22,6 +22,7 @@ class MandatoryPhoneNumber(models.Model):
 class OptionalPhoneNumber(models.Model):
     phone_number = PhoneNumberField(blank=True, default='')
 
+
 class NullablePhoneNumber(models.Model):
     phone_number = PhoneNumberField(null=True)
 
@@ -94,7 +95,8 @@ class PhoneNumberFieldTestCase(TestCase):
         Aggregate of tests to perform for db storage formats
         '''
         self.test_objects_with_same_number_are_equal()
-        self.test_field_returns_correct_type()
+        self.test_blank_field_returns_empty_string()
+        self.test_null_field_returns_none()
         self.test_can_assign_string_phone_number()
 
     def test_storage_formats(self):

--- a/phonenumber_field/tests.py
+++ b/phonenumber_field/tests.py
@@ -22,6 +22,8 @@ class MandatoryPhoneNumber(models.Model):
 class OptionalPhoneNumber(models.Model):
     phone_number = PhoneNumberField(blank=True, default='')
 
+class NullablePhoneNumber(models.Model):
+    phone_number = PhoneNumberField(null=True)
 
 ##############
 # Test Cases #
@@ -63,9 +65,15 @@ class PhoneNumberFieldTestCase(TestCase):
         self.assertTrue(all(is_number_match(n, numbers[0]) == MatchType.EXACT_MATCH
                         for n in numbers))
 
-    def test_field_returns_correct_type(self):
+    def test_blank_field_returns_empty_string(self):
         model = OptionalPhoneNumber()
         self.assertEqual(model.phone_number, '')
+        model.phone_number = '+49 176 96842671'
+        self.assertEqual(type(model.phone_number), PhoneNumber)
+        
+    def test_null_field_returns_none(self):
+        model = NullablePhoneNumber()
+        self.assertEqual(model.phone_number, None)
         model.phone_number = '+49 176 96842671'
         self.assertEqual(type(model.phone_number), PhoneNumber)
 

--- a/phonenumber_field/tests.py
+++ b/phonenumber_field/tests.py
@@ -65,7 +65,7 @@ class PhoneNumberFieldTestCase(TestCase):
 
     def test_field_returns_correct_type(self):
         model = OptionalPhoneNumber()
-        self.assertEqual(model.phone_number, None)
+        self.assertEqual(model.phone_number, '')
         model.phone_number = '+49 176 96842671'
         self.assertEqual(type(model.phone_number), PhoneNumber)
 

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -30,4 +30,4 @@ class PhonenumerFieldAppTest(TestCase):
         
         pk = tm.id
         tm = TestModelBlankPhone.objects.get(pk=pk)
-        self.assertIsNone(tm.phone)
+        self.assertEqual(tm.phone, '')


### PR DESCRIPTION
Currently, when a phone number is `NULL` or it is an empty string, the returned value from `to_python()` is `None`. 

**Steps to reproduce**
1. Use the `PhoneNumberField` model to create a phone number with `blank=true` and `default=''`.
2. Get the value of the phone number.
3. The value will be `None` instead of a blank string.

This can be a bit of a headache when it comes to using an already-entered value in an editable field.

This change allows the phone number to be pulled from the database as a blank string if it's blank, or as `None` if it's value is `NULL` in the database.

This request also updates the appropriate tests regarding this change.