### PR TITLE
Add babel as python package install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     description="An international phone number field for django models.",
     install_requires=[
         'phonenumbers>=7.0.2',
+        'babel',
     ],
     long_description=open('README.rst').read(),
     author='Stefan Foulis',


### PR DESCRIPTION
Add babel as python package install dependency. Babel is used in
phonenumber_field.widget.

Fix issue #53