### PR TITLE
Correct to_python for phonenumbers.phonenumber.PhoneNumber type values

### DIFF
--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -87,7 +87,8 @@ def to_python(value):
             phone_number = PhoneNumber(raw_input=value)
     elif (isinstance(value, phonenumbers.phonenumber.PhoneNumber) and
           not isinstance(value, PhoneNumber)):
-        phone_number = PhoneNumber(value)
+        phone_number = PhoneNumber()
+        phone_number.merge_from(value)
     elif isinstance(value, PhoneNumber):
         phone_number = value
     else:


### PR DESCRIPTION
Correct issue #77 

Function to_python for values with type of
phonenumbers.phonenumber.PhoneNumber must use merge_from method of this
class. It is not possible simply cast value because constructur does not
support it (its first argument is country_code).

Add tests for it.