### PR TITLE
Allow overriding ValidationError message

### DIFF
--- a/phonenumber_field/validators.py
+++ b/phonenumber_field/validators.py
@@ -10,4 +10,4 @@ from phonenumber_field.phonenumber import to_python
 def validate_international_phonenumber(value):
     phone_number = to_python(value)
     if phone_number and not phone_number.is_valid():
-        raise ValidationError(_('The phone number entered is not valid.'))
+        raise ValidationError(_('The phone number entered is not valid.'), code='invalid')


### PR DESCRIPTION
By providing a `code`, this allows to override the error message. For example, now the validator can be used like this:

    number = forms.CharField(label=_("Phone Number"),
                             error_messages={'invalid': _('Enter a valid phone number.')}, 
                             validators=[validate_international_phonenumber])
