### PR TITLE
Simplify string formating functions

### DIFF
--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -40,9 +40,7 @@ class PhoneNumber(phonenumbers.phonenumber.PhoneNumber):
     def __unicode__(self):
         format_string = getattr(settings, 'PHONENUMBER_DEFAULT_FORMAT', 'E164')
         fmt = self.format_map[format_string]
-        if self.is_valid():
-            return self.format_as(fmt)
-        return self.raw_input
+        return self.format_as(fmt)
 
     def is_valid(self):
         """
@@ -51,10 +49,7 @@ class PhoneNumber(phonenumbers.phonenumber.PhoneNumber):
         return phonenumbers.is_valid_number(self)
 
     def format_as(self, format):
-        if self.is_valid():
-            return phonenumbers.format_number(self, format)
-        else:
-            return self.raw_input
+        return phonenumbers.format_number(self, format)
 
     @property
     def as_international(self):


### PR DESCRIPTION
String formating functions
 - ```__unicode__```
 - ```format_as```

both of these functions implement decision how to format invalid phone
number. Moreover ```__unicode__``` calls for its result ```format_as``` function. So
```__unicode__``` duplicates some functionality of ```format_as```. Therefore is not
necessary to check validity in ```__unicode__``` and instead directly call
```format_as``` without conditions.

```format_as``` function implement decision how to format invalid phone
number. But the same decision is made in ```phonenumbers.format_number```
which ```format_as``` calls for its result. Therefore is not necessary to
check validity in ```format_as``` function and instead directly call
```phonenumbers.format_number``` without conditions.