### PR TITLE
Fix #87 Overwrite PhoneNumber parent __eq__

### DIFF
--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -75,6 +75,32 @@ class PhoneNumber(phonenumbers.phonenumber.PhoneNumber):
     def __len__(self):
         return len(self.__unicode__())
 
+    def __eq__(self, other):
+        """
+        Override parent equality because we store only string representation
+        of phone number, so we must compare only this string representation
+        """
+        if (isinstance(other, PhoneNumber) or
+                isinstance(other, phonenumbers.phonenumber.PhoneNumber) or
+                isinstance(other, string_types)):
+            format_string = getattr(settings, 'PHONENUMBER_DB_FORMAT', 'E164')
+            default_region = getattr(settings, 'PHONENUMBER_DEFAULT_REGION',
+                                     None)
+            fmt = self.format_map[format_string]
+            if isinstance(other, string_types):
+                # convert string to phonenumbers.phonenumber.PhoneNumber
+                # instance
+                try:
+                    other = phonenumbers.phonenumberutil.parse(
+                        other, region=default_region)
+                except NumberParseException:
+                    # Conversion is not possible, thus not equal
+                    return False
+            other_string = phonenumbers.format_number(other, fmt)
+            return self.format_as(fmt) == other_string
+        else:
+            return False
+
 
 def to_python(value):
     if value in validators.EMPTY_VALUES:  # None or ''

--- a/phonenumber_field/tests.py
+++ b/phonenumber_field/tests.py
@@ -65,13 +65,17 @@ class PhoneNumberFieldTestCase(TestCase):
         self.assertTrue(
             all(phonenumbers.is_number_match(n, numbers[0]) ==
                 phonenumbers.MatchType.EXACT_MATCH for n in numbers))
+        for number in numbers:
+            self.assertEqual(number, numbers[0])
+            for number_string in self.equal_number_strings:
+                self.assertEqual(number, number_string)
 
     def test_blank_field_returns_empty_string(self):
         model = OptionalPhoneNumber()
         self.assertEqual(model.phone_number, '')
         model.phone_number = '+49 176 96842671'
         self.assertEqual(type(model.phone_number), PhoneNumber)
-        
+
     def test_null_field_returns_none(self):
         model = NullablePhoneNumber()
         self.assertEqual(model.phone_number, None)


### PR DESCRIPTION
Fix #87 issue.

Override parent (phonenumbers.phonenumber.PhoneNumber) equality test
because we store only string representation of phone number, so we must
compare only this string representation not whole structure as do parent
class.

Added test for equality comparison.