### PR TITLE
Allow empty value for PhoneNumberPrefixWidget

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -56,4 +56,4 @@ class PhoneNumberPrefixWidget(MultiWidget):
     def value_from_datadict(self, data, files, name):
         values = super(PhoneNumberPrefixWidget, self).value_from_datadict(
             data, files, name)
-        return '%s.%s' % tuple(values)
+        return '%s%s' % tuple(values)

--- a/testproject/testapp/forms.py
+++ b/testproject/testapp/forms.py
@@ -1,0 +1,12 @@
+from django import forms
+from testapp.models import TestModelBlankPhone
+from phonenumber_field.formfields import PhoneNumberField
+from phonenumber_field.widgets import PhoneNumberPrefixWidget
+
+
+class TestFormWidget(forms.ModelForm):
+    phone = PhoneNumberField(required=False, widget=PhoneNumberPrefixWidget())
+
+    class Meta:
+        model = TestModelBlankPhone
+        fields = "__all__"

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -31,3 +31,34 @@ class PhonenumerFieldAppTest(TestCase):
         pk = tm.id
         tm = TestModelBlankPhone.objects.get(pk=pk)
         self.assertEqual(tm.phone, '')
+
+    def test_save_phone_to_database_with_phone_number_prefix_widget(self):
+        from testapp.forms import TestFormWidget
+        from testapp.models import TestModelBlankPhone
+        tf = TestFormWidget(data={'phone_0': '+374', 'phone_1': '94123456'})
+        self.assertTrue(tf.is_valid())
+
+        tm = tf.save()
+
+        pk = tm.id
+        tm = TestModelBlankPhone.objects.get(pk=pk)
+        self.assertEqual(tm.phone, '+37494123456')
+
+    def test_wrong_phone_save_to_database_with_phone_number_prefix_widget_fail(self):
+        from testapp.forms import TestFormWidget
+        from testapp.models import TestModelBlankPhone
+        tf = TestFormWidget(data={'phone_0': '+3', 'phone_1': '94123456'})
+        self.assertFalse(tf.is_valid())
+
+    def test_save_blank_phone_to_database_with_phone_number_prefix_widget(self):
+        from testapp.forms import TestFormWidget
+        from testapp.models import TestModelBlankPhone
+        tf = TestFormWidget(data={'phone_0': '', 'phone_1': ''})
+        self.assertTrue(tf.is_valid())
+
+        tm = tf.save()
+
+        pk = tm.id
+        tm = TestModelBlankPhone.objects.get(pk=pk)
+        self.assertEqual(tm.phone, '')
+


### PR DESCRIPTION
When you are using PhoneNumberPrefixWidget you are not able to leave phone field blank because of dot added between phone prefix and actual phone value