### PR TITLE
Add a new widget for smart switching between national and international formats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,8 @@ Included are:
 * ``PhoneNumber``, a pythonic wrapper around ``python-phonenumbers``' ``PhoneNumber`` class
 * ``PhoneNumberField``, a model field
 * ``PhoneNumberField``, a form field
-* ``PhoneNumberPrefixWidget``, a form widget
+* ``PhoneNumberPrefixWidget``, a form widget for selecting a region code and entering a national number
+* ``PhoneNumberInternationalFallbackWidget``, a form widget that uses national numbers unless an international number is entered
 
 Installation
 ============

--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from babel import Locale
+from django.conf import settings
 from django.forms import Select, TextInput
 from django.forms.widgets import MultiWidget
 from django.utils import translation
 from phonenumbers.data import _COUNTRY_CODE_TO_REGION_CODE
+from phonenumbers import PhoneNumberFormat
+from phonenumbers.phonenumberutil import region_code_for_number
 
 from phonenumber_field.phonenumber import PhoneNumber
 
@@ -57,3 +60,27 @@ class PhoneNumberPrefixWidget(MultiWidget):
         values = super(PhoneNumberPrefixWidget, self).value_from_datadict(
             data, files, name)
         return '%s.%s' % tuple(values)
+
+
+class PhoneNumberInternationalFallbackWidget(TextInput):
+    """
+    A Widget that allows a phone number in a national format, but if given
+    an international number will fall back to international format
+    """
+
+    def __init__(self, region=None, attrs=None):
+        if region is None:
+            region = (getattr(settings, 'PHONENUMBER_DEFAULT_REGION', None)
+                      or getattr(settings, 'PHONENUMER_DEFAULT_REGION', None))
+        self.region = region
+        super(PhoneNumberInternationalFallbackWidget, self).__init__(attrs)
+
+    def _format_value(self, value):
+        if isinstance(value, PhoneNumber):
+            number_region = region_code_for_number(value)
+            if self.region != number_region:
+                formatter = PhoneNumberFormat.INTERNATIONAL
+            else:
+                formatter = PhoneNumberFormat.NATIONAL
+            return value.format_as(formatter)
+        return super(PhoneNumberInternationalFallbackWidget, self)._format_value(value)


### PR DESCRIPTION
Currently, if using `PHONENUMBER_DEFAULT_FORMAT = 'NATIONAL'` numbers that are entered in international format lose their country information on loading the form, meaning they cannot be validated. 
This widget checks if the number provided is in the expected region and renders it in national format if so, or international if there's a mismatch.