### PR TITLE
Update modelfields.py to address Issue #123

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -73,6 +73,10 @@ class PhoneNumberField(models.Field):
             return value
         format_string = getattr(settings, 'PHONENUMBER_DB_FORMAT', 'E164')
         fmt = PhoneNumber.format_map[format_string]
+        
+        if value is None:
+            return ''
+        
         return value.format_as(fmt)
 
     def contribute_to_class(self, cls, name):
@@ -85,6 +89,11 @@ class PhoneNumberField(models.Field):
         }
         defaults.update(kwargs)
         return super(PhoneNumberField, self).formfield(**defaults)
+        
+    def deconstruct(self):
+        name, path, args, kwargs = super(PhoneNumberField, self).deconstruct()
+        del kwargs["max_length"]
+        return name, path, args, kwargs
 
 
 try:


### PR DESCRIPTION
The patch to get_prep_value() allows manage.py migrate to successfully complete. This is to address issue "Running migration on phonenumberfield results in AttributeError #123"

As per https://docs.djangoproject.com/en/1.8/howto/custom-model-fields/#custom-field-deconstruct-method, I also added the deconstruct method. I don't know if my migration will run without this, but figure since it's required, it should stay.