### PR TITLE
Correct form validation with empty fields

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -59,6 +59,8 @@ class PhoneNumberPrefixWidget(MultiWidget):
     def value_from_datadict(self, data, files, name):
         values = super(PhoneNumberPrefixWidget, self).value_from_datadict(
             data, files, name)
+        if not any(values):
+            return None
         return '%s.%s' % tuple(values)
 
 


### PR DESCRIPTION
This PR refers to #71.

Empty forms of an formset were treated as not valid because the sting "." was retuned and not None.
