### PR TITLE
Empty select fix

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -17,7 +17,7 @@ class PhonePrefixSelect(Select):
 
     def __init__(self, initial=None):
         choices = [('', '---------')]
-        language = translation.get_language()
+        language = translation.get_language() or settings.LANGUAGE_CODE
         if language:
             locale = Locale(translation.to_locale(language))
             for prefix, values in _COUNTRY_CODE_TO_REGION_CODE.items():


### PR DESCRIPTION
Fallback to settings.LANGUAGE_CODE when translation is not active and returns None
https://docs.djangoproject.com/es/1.9/ref/utils/#django.utils.translation.get_language