### PR TITLE
Add installation instructions to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,16 @@ Installation
 Basic usage
 ===========
 
-Use it like any regular model field::
+First, add ``phonenumber_field`` to the list of the installed apps in 
+your ``settings.py`` file::
+
+    INSTALLED_APPS = [
+        ...
+        'phonenumber_field',
+        ...
+    ]
+
+Then, you can use it like any regular model field::
 
     from phonenumber_field.modelfields import PhoneNumberField
 


### PR DESCRIPTION
`README` was missing installation instructions (which app name to add in `INSTALLED_APPS`), so I added those.

No production code change.