### PR TITLE
Don't raise an AttributeError when accessing a PhoneNumberDescriptor

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -29,9 +29,7 @@ class PhoneNumberDescriptor(object):
 
     def __get__(self, instance=None, owner=None):
         if instance is None:
-            raise AttributeError(
-                "The '%s' attribute can only be accessed from %s instances."
-                % (self.field.name, owner.__name__))
+            return self
         return instance.__dict__[self.field.name]
 
     def __set__(self, instance, value):

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -165,3 +165,8 @@ class PhonenumerFieldAppTest(TestCase):
         """Field Test for when Blank, Empty Default, Null & Unique"""
         from testapp.models import TestModelPhoneBEDNU as TestModel
         self.__test_nullable_empty_default_field_helper(TestModel)
+
+    def test_model_attribute_can_be_accessed_on_class(self):
+        from testapp.models import TestModel
+        from phonenumber_field.modelfields import PhoneNumberDescriptor
+        self.assertIsInstance(TestModel.phone, PhoneNumberDescriptor)


### PR DESCRIPTION
This fixes compatibility with Django 1.11 when initializing a model
instance with kwargs values such as TestModel(name='name').

Model initialization was changed in Django 1.11 and now tries to
access fields to check their class in Options._property_names()
in django/db/model/options.py.

https://github.com/django/django/blob/master/django/db/models/options.py#L837