### PR TITLE
Python 3.6 invalid escape sequence deprecation fix

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -88,6 +88,6 @@ try:
             [],
             {},
         ),
-    ], ["^phonenumber_field\.modelfields\.PhoneNumberField"])
+    ], [r"^phonenumber_field\.modelfields\.PhoneNumberField"])
 except ImportError:
     pass


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior