### PR TITLE
Use static install_requires list so wheels install properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,8 @@
 from setuptools import setup, find_packages
-import pkgutil
 
 from phonenumber_field import __version__
 
-install_requires = ['Django>=1.11', 'babel']
-if 'phonenumbers' not in [p[1] for p in pkgutil.iter_modules()]:
-    install_requires.append('phonenumberslite>=7.0.2')
+install_requires = ['Django>=1.11', 'babel', 'phonenumbers>=7.0.2']
 
 setup(
     name="django-phonenumber-field",


### PR DESCRIPTION
The current approach to conditionally installing `phonenumberslite` runs into a [cache poisoning issue](https://github.com/pypa/pip/issues/3025) with pip. 

Projects could avoid the problem with `--no-binary`, but I'm not sure of a solution for packages.

The wheel format does not support conditional dependencies and only offers environment markers as an alternative, so I've just swapped to a static dependency on `phonenumbers`.