### PR TITLE
remove hardcoded dependency to phonenumbers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+next
+----
+
+* Removed hardcoded dependency to phonenumbers library. Now developers have to
+  manually install either honenumbers or phonenumberslite.
+
+
 2.0.1 (2018-08-19)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,11 @@ Installation
 ::
 
     pip install django-phonenumber-field
+    pip install phonenumbers
+
+As a an alternative to the ``phonenumbers`` package it is possible to install the
+``phonenumberslite`` package which has
+`a lower memory footprint <https://github.com/daviddrysdale/python-phonenumbers#memory-usage>`_.
 
 
 Basic usage

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,11 @@ setup(
     install_requires=[
         'Django>=1.11.3',
         'babel',
-        'phonenumbers>=7.0.2',
     ],
+    extras_require={
+        'phonenumbers': ['phonenumbers>=7.0.2'],
+        'phonenumberslite': ['phonenumberslite>=7.0.2'],
+    },
     long_description=open('README.rst').read(),
     author='Stefan Foulis',
     author_email='stefan@foulis.ch',

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     pytest-django
     pytest-cov
     pytest-pythonpath
+extras = phonenumberslite
 whitelist_commands =
     django-admin
 commands =


### PR DESCRIPTION
Now it is up to the developer to install phonenumbers or phonenumberslite