### PR TITLE
✅ skip testing with pypy because it does not work

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     begin
     flake8
-    py{27,34,35,36,py,py3}-dj{111}
+    py{27,34,35,36,py3}-dj{111}
     py{34,35,36,37}-dj{20}
     py{35,36,37}-dj{21,master}
     end
@@ -55,7 +55,6 @@ python =
     3.5: py35
     3.6: py36, flake8
     3.7: py37
-    pypy: pypy
     pypy3: pypy3
 
 [travis:env]


### PR DESCRIPTION
(only applies to pypy2. pypy3 is still tested and supported)