### PR TITLE
Add by region lookup method for phonenumberfields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ As a an alternative to the ``phonenumbers`` package it is possible to install th
 Basic usage
 ===========
 
-First, add ``phonenumber_field`` to the list of the installed apps in 
+First, add ``phonenumber_field`` to the list of the installed apps in
 your ``settings.py`` file::
 
     INSTALLED_APPS = [
@@ -75,6 +75,14 @@ As with ``CharField``'s, it is discouraged to use ``null=True``.
 The object returned is a PhoneNumber instance, not a string. If strings are used to initialize it,
 e.g. via ``MyModel(phone_number='+41524204242')`` or form handling, it has to be a phone number
 with country code.
+
+
+Lookup by region
+----------------
+
+It's possible to lookup numbers using region like 'US', 'UK', etc::
+
+    MyModel.objects.filter(phone_number__region='UK')
 
 
 Running tests
@@ -111,4 +119,3 @@ re-create the virtual environments.
 
 After a full test run the coverage report will be available at
 ``htmlcov/index.html``.
-

--- a/phonenumber_field/tests.py
+++ b/phonenumber_field/tests.py
@@ -49,6 +49,11 @@ class PhoneNumberFieldTestCase(TestCase):
     local_numbers = [
         ('GB', '01606 751 78'),
         ('DE', '0176/96842671'),
+        ('US', '202-555-0123'),
+        ('IT', '0346 3368300'),
+        ('CA', '613-555-0107'),
+        ('KZ', '7172 72-17-05'),
+        ('RU', '495 606-98-88'),
     ]
     storage_numbers = {
         'E164': ['+44 113 8921113', '+441138921113'],
@@ -82,6 +87,30 @@ class PhoneNumberFieldTestCase(TestCase):
             self.assertEqual(number, numbers[0])
             for number_string in self.equal_number_strings:
                 self.assertEqual(number, number_string)
+
+    def test_lookup_region(self):
+        numbers = {
+            region: MandatoryPhoneNumber.objects.create(
+                phone_number=PhoneNumber.from_string(number_string,
+                                                     region=region)
+            ) for region, number_string in self.local_numbers
+        }
+        self.assertFalse(
+            MandatoryPhoneNumber.objects.filter(phone_number__region='FR')
+        )
+
+        for region, number in numbers.items():
+            item = MandatoryPhoneNumber.objects.get(
+                phone_number__region=region
+            )
+            self.assertEqual(item, number)
+            qs = MandatoryPhoneNumber.objects.exclude(
+                phone_number__region=region
+            )
+            self.assertNotIn(
+                number,
+                [n.phone_number for n in qs]
+            )
 
     def test_same_number_has_same_hash(self):
         numbers = [PhoneNumber.from_string(number_string)


### PR DESCRIPTION
Phone numbers can be found using associated region like 'FR', 'UK', 'US', etc.

	queryset.filter(phone_number_field__region='FR)
	queryset.get(phone_numer_field__region='UK')

Using startswith pattern with region codes

	LIKE '+44%';