### PR TITLE
Add testing for Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - DJANGO="1.11"
   - DJANGO="2.0"
   - DJANGO="2.1"
+  - DJANGO="2.2"
 matrix:
   include:
     - python: 2.7

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     flake8
     py{27,34,35,36,py3}-dj{111}
     py{34,35,36,37}-dj{20}
-    py{35,36,37}-dj{21,master}
+    py{35,36,37}-dj{21,22,master}
     end
 
 [testenv:flake8]
@@ -19,6 +19,7 @@ deps =
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1a1,<2.2
+    dj22: Django>=2.2a1,<3.0
     djmaster: https://github.com/django/django/archive/master.tar.gz
 
     pytest
@@ -62,3 +63,4 @@ DJANGO =
     1.11: dj111
     2.0: dj20
     2.1: dj21
+    2.2: dj22


### PR DESCRIPTION
Django 2.2 alpha 1 was released January 17, 2019. Begin testing against
it now to ensure compatibility upon release.

https://www.djangoproject.com/weblog/2019/jan/17/django-22-alpha-1/