### PR TITLE
Add region argument to PhoneNumberField

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 CHANGELOG
 =========
 
+* Added the ``region`` keyword argument to ``PhoneNumberField``.
+
 2.2.0 (2019-01-27)
 ------------------
 

--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.forms.fields import CharField
 from django.utils.translation import ugettext_lazy as _
 
-from phonenumber_field.phonenumber import to_python
+from phonenumber_field.phonenumber import to_python, validate_region
 from phonenumber_field.validators import validate_international_phonenumber
 
 
@@ -15,11 +15,13 @@ class PhoneNumberField(CharField):
     default_validators = [validate_international_phonenumber]
 
     def __init__(self, *args, **kwargs):
+        self.region = kwargs.pop("region", None)
+        validate_region(self.region)
         super(PhoneNumberField, self).__init__(*args, **kwargs)
         self.widget.input_type = "tel"
 
     def to_python(self, value):
-        phone_number = to_python(value)
+        phone_number = to_python(value, region=self.region)
 
         if phone_number in validators.EMPTY_VALUES:
             return self.empty_value

--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -108,12 +108,12 @@ class PhoneNumber(phonenumbers.PhoneNumber):
         return hash(self.__unicode__())
 
 
-def to_python(value):
+def to_python(value, region=None):
     if value in validators.EMPTY_VALUES:  # None or ''
         phone_number = value
     elif value and isinstance(value, string_types):
         try:
-            phone_number = PhoneNumber.from_string(phone_number=value)
+            phone_number = PhoneNumber.from_string(phone_number=value, region=region)
         except phonenumbers.NumberParseException:
             # the string provided is not a valid PhoneNumber.
             phone_number = PhoneNumber(raw_input=value)
@@ -130,3 +130,14 @@ def to_python(value):
         #       (Same for the phonenumbers.NumberParseException above)
         phone_number = None
     return phone_number
+
+
+def validate_region(region):
+    if (
+        region is not None
+        and region not in phonenumbers.shortdata._AVAILABLE_REGION_CODES
+    ):
+        raise ValueError(
+            "“%s” is not a valid region code. Choices are %r"
+            % (region, phonenumbers.shortdata._AVAILABLE_REGION_CODES)
+        )

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -65,3 +65,7 @@ class TestModelPhoneBEDNU(models.Model):
     name = models.CharField(max_length=255, blank=True, default='')
     phone = PhoneNumberField(
         blank=True, default='', null=True, unique=True)
+
+
+class FrenchPhoneOwner(models.Model):
+    cell_number = PhoneNumberField(region="FR")


### PR DESCRIPTION
The `PHONENUMBER_DEFAULT_REGION` setting is applied system-wide, when the application is loaded. In my use case, the default region is set by users and may change during runtime.