### PR TITLE
Remove model field to_python call in get_prep_value

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -59,7 +59,6 @@ class PhoneNumberField(models.Field):
         Perform preliminary non-db specific value checks and conversions.
         """
         value = super(PhoneNumberField, self).get_prep_value(value)
-        value = to_python(value)
         if not isinstance(value, PhoneNumber):
             return value
         format_string = getattr(settings, "PHONENUMBER_DB_FORMAT", "E164")


### PR DESCRIPTION
The model instance has been set through the descriptor's `__set__`, `to_python` has already been called there, I believe this call is a duplicate.