### PR TITLE
Remove INSTALLED_APPS section from README

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 CHANGELOG
 =========
 
+* Remove recommendation to add ``phonenumber_field`` to the ``INSTALLED_APPS``.
+
 2.2.0 (2019-01-27)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -43,16 +43,7 @@ As a an alternative to the ``phonenumbers`` package it is possible to install th
 Basic usage
 ===========
 
-First, add ``phonenumber_field`` to the list of the installed apps in 
-your ``settings.py`` file::
-
-    INSTALLED_APPS = [
-        ...
-        'phonenumber_field',
-        ...
-    ]
-
-Then, you can use it like any regular model field::
+Just like any regular model field::
 
     from phonenumber_field.modelfields import PhoneNumberField
 

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -121,7 +121,6 @@ INSTALLED_APPS = (
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
-    'phonenumber_field',
     'testapp',
 )
 


### PR DESCRIPTION
This app has no models and is not configurable through an `AppConfig`, there's no benefit to add it to Django's `INSTALLED_APPS`. Removing that section makes installation quicker.