### PR TITLE
Use dict setdefault instead of reimplementing it

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -47,7 +47,7 @@ class PhoneNumberField(models.Field):
     description = _("Phone number")
 
     def __init__(self, *args, **kwargs):
-        kwargs["max_length"] = kwargs.get("max_length", 128)
+        kwargs.setdefault("max_length", 128)
         super(PhoneNumberField, self).__init__(*args, **kwargs)
         self.validators.append(validators.MaxLengthValidator(self.max_length))
 


### PR DESCRIPTION
It's clearer in intent, and slightly faster.

```bash
$ python -m timeit 'd = {}; d.setdefault("a", 12)'
5000000 loops, best of 5: 96.2 nsec per loop
$ python -m timeit 'd = {}; d["a"] = d.get("a", 12)'
2000000 loops, best of 5: 107 nsec per loop
```