### PR TITLE
Use shorter and more precise assertQuerysetEqual

### DIFF
--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -9,6 +9,10 @@ from django.db.models import Q
 from django.test import TestCase
 
 
+def phone_transform(obj):
+    return (obj.pk, obj.name, obj.phone)
+
+
 class PhonenumerFieldAppTest(TestCase):
     def test_save_field_to_database(self):
         """Basic Field Test"""
@@ -22,19 +26,11 @@ class PhonenumerFieldAppTest(TestCase):
 
         tm = TestModel.objects.get(pk=pk)
         self.assertTrue(isinstance(tm.phone, PhoneNumber))
-        self.assertEqual(str(tm.phone), '+41524242424')
-        self.assertEqual(
-            1,
-            TestModel.objects
-                .exclude(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
-        self.assertEqual(
-            0,
-            TestModel.objects
-                .filter(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
+        self.assertQuerysetEqual(
+            TestModel.objects.all(),
+            [(tm.pk, "", "+41524242424")],
+            transform=phone_transform,
+        )
 
     def test_save_blank_phone_to_database(self):
         """Field Test for when Blank"""
@@ -44,19 +40,9 @@ class PhonenumerFieldAppTest(TestCase):
 
         pk = tm.id
         tm = TestModel.objects.get(pk=pk)
-        self.assertEqual(tm.phone, '')
-        self.assertEqual(
-            0,
-            TestModel.objects
-                .exclude(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
-        self.assertEqual(
-            1,
-            TestModel.objects
-                .filter(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
+        self.assertQuerysetEqual(
+            TestModel.objects.all(), [(tm.pk, "", "")], transform=phone_transform,
+        )
 
     def __test_nullable_field_helper(self, TestModel):
         """Helper method for the next four tests."""
@@ -66,21 +52,11 @@ class PhonenumerFieldAppTest(TestCase):
         pk = tm.id
         tm = TestModel.objects.get(pk=pk)
         self.assertIsNone(tm.phone)
-        self.assertEqual(
-            0,
-            TestModel.objects
-                .exclude(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
-        self.assertEqual(
-            1,
-            TestModel.objects
-                .filter(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
+        self.assertQuerysetEqual(
+            TestModel.objects.all(), [(tm.pk, "", None)], transform=phone_transform,
+        )
 
         # ensure that null values do not cause uniqueness conflicts
-        self.assertEqual(TestModel.objects.count(), 1)
         TestModel.objects.create()
         self.assertEqual(TestModel.objects.count(), 2)
 
@@ -111,19 +87,11 @@ class PhonenumerFieldAppTest(TestCase):
 
         pk = tm.id
         tm = TestModel.objects.get(pk=pk)
-        self.assertEqual(str(tm.phone), '+41524242424')
-        self.assertEqual(
-            1,
-            TestModel.objects
-                .exclude(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
-        self.assertEqual(
-            0,
-            TestModel.objects
-                .filter(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
+        self.assertQuerysetEqual(
+            TestModel.objects.all(),
+            [(tm.pk, "", "+41524242424")],
+            transform=phone_transform,
+        )
 
     def test_save_unique_null_default_phone_to_database(self):
         """Field Test for when Default, Null & Unique"""
@@ -142,19 +110,9 @@ class PhonenumerFieldAppTest(TestCase):
 
         pk = tm.id
         tm = TestModel.objects.get(pk=pk)
-        self.assertEqual(tm.phone, '')
-        self.assertEqual(
-            0,
-            TestModel.objects
-                .exclude(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
-        self.assertEqual(
-            1,
-            TestModel.objects
-                .filter(Q(phone__isnull=True) | Q(phone=''))
-                .filter(pk=pk)
-                .count())
+        self.assertQuerysetEqual(
+            TestModel.objects.all(), [(tm.pk, "", "")], transform=phone_transform,
+        )
 
     def test_save_unique_null_default_empty_phone_to_database(self):
         """Field Test for when Empty Default, Null & Unique"""


### PR DESCRIPTION
`assertQuerysetEqual` can check all attributes of objects pulled out of the database. It does so in a single query, avoiding the current `exclude` / `filter` dance.