### PR TITLE
Remove unsupported py35-djmaster from the test matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     flake8
     py{27,34,35,36,py3}-dj{111}
     py{34,35,36,37}-dj{20}
-    py{35,36,37}-dj{21,22,master}
+    py{35,36,37}-dj{21,22}
+    py{36,37}-djmaster
     end
 
 [testenv:flake8]


### PR DESCRIPTION
Django removed Python 3.5 support in commit
https://github.com/django/django/commit/7e6b214ed34f5562dbd83cf54924a5b589a29715