### PR TITLE
Drop alpha from Django 2.1 version range

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = flake8
 deps =
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1a1,<2.2
+    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2a1,<3.0
     djmaster: https://github.com/django/django/archive/master.tar.gz
 


### PR DESCRIPTION
Only test against the official production release.