### PR TITLE
Include tox.ini in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
 include README.rst
+include tox.ini
 recursive-include phonenumber_field/locale django.mo django.po
 recursive-include tests *.py


### PR DESCRIPTION
The sdist should contains all files necessary to test the package.