### PR TITLE
Test against for Django 2.2 release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
-    dj22: Django>=2.2a1,<3.0
+    dj22: Django>=2.2,<3.0
     djmaster: https://github.com/django/django/archive/master.tar.gz
 extras = phonenumberslite
 commands =


### PR DESCRIPTION
Announcement:
https://www.djangoproject.com/weblog/2019/apr/01/django-22-released/

Release notes:
https://docs.djangoproject.com/en/2.2/releases/2.2/