### PR TITLE
Use the PHONENUMBER_DEFAULT_REGION if region is not specified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ UNRELEASED
 * A ``PhoneNumberField`` can now be deferred with ``QuerySet.defer()``.
 * Saving or filtering by an invalid phone number will now raise a
   ``ValueError``.
+* The model field attribute ``PhoneNumberField.region`` now uses
+  ``PHONENUMBER_DEFAULT_REGION`` if not specified.
 
 2.3.1 (2019-03-26)
 ------------------

--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -55,8 +55,12 @@ class PhoneNumberField(models.CharField):
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("max_length", 128)
-        self.region = kwargs.pop("region", None)
+        self._region = kwargs.pop("region", None)
         super(PhoneNumberField, self).__init__(*args, **kwargs)
+
+    @property
+    def region(self):
+        return self._region or getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
 
     def check(self, **kwargs):
         errors = super(PhoneNumberField, self).check(**kwargs)
@@ -92,7 +96,7 @@ class PhoneNumberField(models.CharField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(PhoneNumberField, self).deconstruct()
-        kwargs["region"] = self.region
+        kwargs["region"] = self._region
         return name, path, args, kwargs
 
     def formfield(self, **kwargs):


### PR DESCRIPTION
For apps that exist in a single region, allows apps to specify a region
once and apply it globally. Changing a setting should not result in
database migrations, so this value is exempt from .deconstruct().