### PR TITLE
Drop support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,12 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-    - env: TOXENV=black
-      python: 3.6
-    - env: TOXENV=flake8
-    - env: TOXENV=isort
-    - python: 2.7
-      env: TOXENV=py27-dj111
-    - python: 3.4
-      env: TOXENV=py34-dj111
+    - python: 3.7
+      env: TOXENV=black
+    - python: 3.7
+      env: TOXENV=flake8
+    - python: 3.7
+      env: TOXENV=isort
     - python: 3.5
       env: TOXENV=py35-dj111
     - python: 3.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,12 @@ UNRELEASED
 ----------
 
 * Update French and Hebrew translations.
-* Drop support for Django 2.0.
 * Add a valid phone number example to invalid phone number error messages.
+
+**Backwards incompatible changes**
+
+* Drop support for Django 2.0.
+* Drop support for Python 2.7 and 3.4.
 
 2.4.0 (2019-05-06)
 ------------------

--- a/phonenumber_field/__init__.py
+++ b/phonenumber_field/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 __version__ = "2.4.0"

--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import phonenumbers
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.forms.fields import CharField
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from phonenumber_field.phonenumber import to_python, validate_region
 from phonenumber_field.validators import validate_international_phonenumber
@@ -15,12 +12,12 @@ class PhoneNumberField(CharField):
     default_error_messages = {}
     default_validators = [validate_international_phonenumber]
 
-    def __init__(self, *args, **kwargs):
-        self.region = kwargs.pop("region", None)
-        validate_region(self.region)
+    def __init__(self, *args, region=None, **kwargs):
+        validate_region(region)
+        self.region = region
 
-        if self.region:
-            number = phonenumbers.example_number(self.region)
+        if region:
+            number = phonenumbers.example_number(region)
             example_number = to_python(number).as_national
             # Translators: {example_number} is a national phone number.
             error_message = _(
@@ -35,7 +32,7 @@ class PhoneNumberField(CharField):
             example_number=example_number
         )
 
-        super(PhoneNumberField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.widget.input_type = "tel"
 
     def to_python(self, value):

--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -1,18 +1,15 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.core import checks
 from django.db import models
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from phonenumber_field import formfields
 from phonenumber_field.phonenumber import PhoneNumber, to_python, validate_region
 from phonenumber_field.validators import validate_international_phonenumber
 
 
-class PhoneNumberDescriptor(object):
+class PhoneNumberDescriptor:
     """
     The descriptor for the phone number attribute on the model instance.
     Returns a PhoneNumber when accessed so you can do stuff like::
@@ -53,17 +50,17 @@ class PhoneNumberField(models.CharField):
 
     description = _("Phone number")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, region=None, **kwargs):
         kwargs.setdefault("max_length", 128)
-        self._region = kwargs.pop("region", None)
-        super(PhoneNumberField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
+        self._region = region
 
     @property
     def region(self):
         return self._region or getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
 
     def check(self, **kwargs):
-        errors = super(PhoneNumberField, self).check(**kwargs)
+        errors = super().check(**kwargs)
         errors.extend(self._check_region())
         return errors
 
@@ -88,14 +85,14 @@ class PhoneNumberField(models.CharField):
             format_string = getattr(settings, "PHONENUMBER_DB_FORMAT", "E164")
             fmt = PhoneNumber.format_map[format_string]
             value = value.format_as(fmt)
-        return super(PhoneNumberField, self).get_prep_value(value)
+        return super().get_prep_value(value)
 
     def contribute_to_class(self, cls, name, *args, **kwargs):
-        super(PhoneNumberField, self).contribute_to_class(cls, name, *args, **kwargs)
+        super().contribute_to_class(cls, name, *args, **kwargs)
         setattr(cls, self.name, self.descriptor_class(self))
 
     def deconstruct(self):
-        name, path, args, kwargs = super(PhoneNumberField, self).deconstruct()
+        name, path, args, kwargs = super().deconstruct()
         kwargs["region"] = self._region
         return name, path, args, kwargs
 
@@ -106,4 +103,4 @@ class PhoneNumberField(models.CharField):
             "error_messages": self.error_messages,
         }
         defaults.update(kwargs)
-        return super(PhoneNumberField, self).formfield(**defaults)
+        return super().formfield(**defaults)

--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -1,17 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-import sys
-
 import phonenumbers
 from django.conf import settings
 from django.core import validators
-
-# Snippet from the `six` library to help with Python3 compatibility
-if sys.version_info[0] == 3:
-    string_types = str
-else:
-    string_types = basestring  # noqa: F821
 
 
 class PhoneNumber(phonenumbers.PhoneNumber):
@@ -41,7 +30,7 @@ class PhoneNumber(phonenumbers.PhoneNumber):
         )
         return phone_number_obj
 
-    def __unicode__(self):
+    def __str__(self):
         format_string = getattr(settings, "PHONENUMBER_DEFAULT_FORMAT", "E164")
         fmt = self.format_map[format_string]
         return self.format_as(fmt)
@@ -72,18 +61,18 @@ class PhoneNumber(phonenumbers.PhoneNumber):
         return self.format_as(phonenumbers.PhoneNumberFormat.RFC3966)
 
     def __len__(self):
-        return len(self.__unicode__())
+        return len(str(self))
 
     def __eq__(self, other):
         """
         Override parent equality because we store only string representation
         of phone number, so we must compare only this string representation
         """
-        if isinstance(other, (string_types, phonenumbers.PhoneNumber)):
+        if isinstance(other, (str, phonenumbers.PhoneNumber)):
             format_string = getattr(settings, "PHONENUMBER_DB_FORMAT", "E164")
             default_region = getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
             fmt = self.format_map[format_string]
-            if isinstance(other, string_types):
+            if isinstance(other, str):
                 # convert string to phonenumbers.PhoneNumber
                 # instance
                 try:
@@ -96,17 +85,14 @@ class PhoneNumber(phonenumbers.PhoneNumber):
         else:
             return False
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __hash__(self):
-        return hash(self.__unicode__())
+        return hash(str(self))
 
 
 def to_python(value, region=None):
     if value in validators.EMPTY_VALUES:  # None or ''
         phone_number = value
-    elif isinstance(value, string_types):
+    elif isinstance(value, str):
         try:
             phone_number = PhoneNumber.from_string(phone_number=value, region=region)
         except phonenumbers.NumberParseException:

--- a/phonenumber_field/serializerfields.py
+++ b/phonenumber_field/serializerfields.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 

--- a/phonenumber_field/validators.py
+++ b/phonenumber_field/validators.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from phonenumber_field.phonenumber import to_python
 

--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from babel import Locale
 from django.conf import settings
 from django.forms import Select, TextInput
@@ -28,15 +25,11 @@ class PhonePrefixSelect(Select):
                 for country_code in values:
                     country_name = locale.territories.get(country_code)
                     if country_name:
-                        choices.append((prefix, "%s %s" % (country_name, prefix)))
-        super(PhonePrefixSelect, self).__init__(
-            choices=sorted(choices, key=lambda item: item[1])
-        )
+                        choices.append((prefix, "{} {}".format(country_name, prefix)))
+        super().__init__(choices=sorted(choices, key=lambda item: item[1]))
 
     def render(self, name, value, *args, **kwargs):
-        return super(PhonePrefixSelect, self).render(
-            name, value or self.initial, *args, **kwargs
-        )
+        return super().render(name, value or self.initial, *args, **kwargs)
 
 
 class PhoneNumberPrefixWidget(MultiWidget):
@@ -48,7 +41,7 @@ class PhoneNumberPrefixWidget(MultiWidget):
 
     def __init__(self, attrs=None, initial=None):
         widgets = (PhonePrefixSelect(initial), TextInput())
-        super(PhoneNumberPrefixWidget, self).__init__(widgets, attrs)
+        super().__init__(widgets, attrs)
 
     def decompress(self, value):
         if value:
@@ -60,9 +53,7 @@ class PhoneNumberPrefixWidget(MultiWidget):
         return [None, ""]
 
     def value_from_datadict(self, data, files, name):
-        values = super(PhoneNumberPrefixWidget, self).value_from_datadict(
-            data, files, name
-        )
+        values = super().value_from_datadict(data, files, name)
         if all(values):
             return "%s.%s" % tuple(values)
         return ""
@@ -78,7 +69,7 @@ class PhoneNumberInternationalFallbackWidget(TextInput):
         if region is None:
             region = getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
         self.region = region
-        super(PhoneNumberInternationalFallbackWidget, self).__init__(attrs)
+        super().__init__(attrs)
 
     def format_value(self, value):
         if isinstance(value, PhoneNumber):
@@ -88,4 +79,4 @@ class PhoneNumberInternationalFallbackWidget(TextInput):
             else:
                 formatter = PhoneNumberFormat.NATIONAL
             return value.format_as(formatter)
-        return super(PhoneNumberInternationalFallbackWidget, self).format_value(value)
+        return super().format_value(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [flake8]
 ignore = W503
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 from phonenumber_field import __version__
@@ -10,7 +9,7 @@ setup(
     license="BSD",
     platforms=["OS Independent"],
     description="An international phone number field for django models.",
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=3.5",
     install_requires=["Django>=1.11.3", "babel"],
     extras_require={
         "phonenumbers": ["phonenumbers>=7.0.2"],
@@ -34,10 +33,8 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/models.py
+++ b/tests/models.py
@@ -19,9 +19,7 @@ class CustomPhoneNumberModelField(PhoneNumberField):
     def formfield(self, **kwargs):
         from .forms import CustomPhoneNumberFormField
 
-        return super(CustomPhoneNumberModelField, self).formfield(
-            form_class=CustomPhoneNumberFormField
-        )
+        return super().formfield(form_class=CustomPhoneNumberFormField)
 
 
 class CustomPhoneNumber(models.Model):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import phonenumbers
 from django import forms
 from django.core import checks

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     black
     flake8
     isort
-    py{27,34,35,36,37}-dj111
+    py{35,36,37}-dj111
     py{35,36,37}-dj21
     py{35,36,37}-dj22
     py{36,37}-djmaster
@@ -24,7 +24,7 @@ commands =
 [testenv:black]
 basepython = python3
 commands =
-    black --check --diff .
+    black --target-version=py35 --check --diff .
 deps =
     black
 skip_install = true


### PR DESCRIPTION
Python 2 support is nearing end of life. At the end of this year, it
will no longer be supported, including for security issues.

Django has already dropped support for Python 2 in Django 2.0. Follow
upstream to be more compatible with the master branch.

For more details, see https://pythonclock.org/

All code changes and clean ups that were noticed were done. Changes
include:

- Remove `str`/`unicode` compatibility shims.
- Remove encoding cookies from source files. Python 3 interprets all
  files as utf-8 by default.
- Remove unnecessary `__future__` imports. The features are now built-in.
- Use modern and simpler `super()` syntax.
- Replace deprecated `ugettext*()` functions with the `gettext*()` versions.
- Replace `__unicode__` with `__str__`.
- Update the wheel configuration to reflect it is no longer universal.
- Update trove classifiers.
- Update Black configuration.

Also remove supported for end of life Python 3.4. It went end of life
2019-03-18.