### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
     - env: TOXENV=isort
     - python: 2.7
       env: TOXENV=py27-dj111
-    - python: 3.4
-      env: TOXENV=py34-dj111
     - python: 3.5
       env: TOXENV=py35-dj111
     - python: 3.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 
 * Improve Hebrew translation.
+* Drop support for Python 3.4.
 
 2.4.0 (2019-05-06)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
     black
     flake8
     isort
-    py{27,34,35,36,37}-dj111
-    py{34,35,36,37}-dj20
+    py{27,35,36,37}-dj111
+    py{35,36,37}-dj20
     py{35,36,37}-dj21
     py{35,36,37}-dj22
     py{36,37}-djmaster


### PR DESCRIPTION
Python 3.4 is not maintained anymore.
https://www.python.org/downloads/release/python-3410/