### PR TITLE
Drop support for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-dj111
     - python: 3.5
-      env: TOXENV=py35-dj20
-    - python: 3.6
-      env: TOXENV=py36-dj20
-    - python: 3.7
-      env: TOXENV=py37-dj20
-    - python: 3.5
       env: TOXENV=py35-dj21
     - python: 3.6
       env: TOXENV=py36-dj21

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 
 * Improve Hebrew translation.
+* Drop support for Django 2.0.
 
 2.4.0 (2019-05-06)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     flake8
     isort
     py{27,34,35,36,37}-dj111
-    py{34,35,36,37}-dj20
     py{35,36,37}-dj21
     py{35,36,37}-dj22
     py{36,37}-djmaster
@@ -14,7 +13,6 @@ minversion = 1.9
 deps =
     coverage
     dj111: Django>=1.11,<1.12
-    dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
     djmaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Django 2.0 is not maintained since Apr 1st, 2019.
https://www.djangoproject.com/download/#supported-versions