### PR TITLE
Fix indentation issue in docstring

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -19,7 +19,9 @@ class PhoneNumberDescriptor:
     Assigns a phone number object on assignment so you can do::
 
         >>> instance.phone_number = PhoneNumber(...)
-    or
+
+    or,
+
         >>> instance.phone_number = '+414204242'
     """
 


### PR DESCRIPTION
This adds a newline before and after the "or" statement. Sphinx expects a newline after codeblock/line.

https://github.com/stefanfoulis/django-phonenumber-field/blob/c1f18eec28245a4aefbff8a71d086b6939e305a4/phonenumber_field/modelfields.py#L21-L23

I know, the project does not have official documentation, but, this helps other projects that use Sphinx, as sphinx goes through all imports and parses docstrings.

This is what I get when I run *sphinx*: `phone_number:9: WARNING: Literal block ends without a blank line; unexpected unindent`

This PR adds a newline after the code, and before the code which fixes the issue.
