### PR TITLE
Fixed #321 - Format example numbers in formfields

### DIFF
--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -1,4 +1,5 @@
 import phonenumbers
+from django.conf import settings
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.forms.fields import CharField
@@ -19,18 +20,18 @@ class PhoneNumberField(CharField):
         self.region = region
 
         if "invalid" not in self.error_messages:
-            if region:
+            # Translators: {example_number} is a national phone number.
+            error_message = _(
+                "Enter a valid phone number (e.g. {example_number}) "
+                "or a number with an international call prefix."
+            )
+            if self.region:
                 number = phonenumbers.example_number(region)
-                example_number = to_python(number).as_national
-                # Translators: {example_number} is a national phone number.
-                error_message = _(
-                    "Enter a valid phone number (e.g. {example_number}) "
-                    "or a number with an international call prefix."
-                )
             else:
-                example_number = "+12125552368"  # Ghostbusters
-                # Translators: {example_number} is an international phone number.
-                error_message = _("Enter a valid phone number (e.g. {example_number}).")
+                number = phonenumbers.example_number(
+                    getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
+                )
+            example_number = to_python(number).as_national
             self.error_messages["invalid"] = error_message.format(
                 example_number=example_number
             )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -369,6 +369,7 @@ class PhonenumerFieldAppTest(TestCase):
 
 
 class PhoneNumberFormFieldTest(TestCase):
+    @override_settings(PHONENUMBER_DEFAULT_REGION="FR")
     def test_error_message(self):
         class PhoneNumberForm(forms.Form):
             number = formfields.PhoneNumberField()
@@ -376,7 +377,13 @@ class PhoneNumberFormFieldTest(TestCase):
         form = PhoneNumberForm({"number": "invalid"})
         self.assertIs(form.is_valid(), False)
         self.assertEqual(
-            form.errors, {"number": ["Enter a valid phone number (e.g. +12125552368)."]}
+            form.errors,
+            {
+                "number": [
+                    "Enter a valid phone number (e.g. 01 23 45 67 89) "
+                    "or a number with an international call prefix."
+                ]
+            },
         )
 
     def test_override_error_message(self):


### PR DESCRIPTION
Format example numbers with `PHONENUMBER_DEFAULT_REGION` in `formfields` error messages if region is not defined.

fixes #321 