### PR TITLE
Use international format if region differs from default

### DIFF
--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -1,6 +1,7 @@
 import phonenumbers
 from django.conf import settings
 from django.core import validators
+from phonenumbers.phonenumberutil import region_code_for_number
 
 
 class PhoneNumber(phonenumbers.PhoneNumber):
@@ -17,6 +18,8 @@ class PhoneNumber(phonenumbers.PhoneNumber):
         "RFC3966": phonenumbers.PhoneNumberFormat.RFC3966,
     }
 
+    default_format = "E164"
+
     @classmethod
     def from_string(cls, phone_number, region=None):
         phone_number_obj = cls()
@@ -31,7 +34,15 @@ class PhoneNumber(phonenumbers.PhoneNumber):
         return phone_number_obj
 
     def __str__(self):
-        format_string = getattr(settings, "PHONENUMBER_DEFAULT_FORMAT", "E164")
+        format_string = getattr(
+            settings, "PHONENUMBER_DEFAULT_FORMAT", self.default_format
+        )
+        region = getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
+        number_region = region_code_for_number(self)
+        if region and region != number_region and self.is_valid():
+            format_string = getattr(
+                settings, "PHONENUMBER_GLOBAL_FORMAT", self.default_format
+            )
         fmt = self.format_map[format_string]
         return self.format_as(fmt)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -520,3 +520,15 @@ class RegionPhoneNumberModelFieldTest(TestCase):
     def test_region_none(self):
         field = modelfields.PhoneNumberField()
         self.assertIsNone(field.region)
+
+    @override_settings(
+        PHONENUMBER_DEFAULT_REGION="US", PHONENUMBER_DEFAULT_FORMAT="NATIONAL"
+    )
+    def test_international_phone_is_valid(self):
+        class PhoneNumberForm(forms.ModelForm):
+            class Meta:
+                model = models.TestModel
+                fields = "__all__"
+
+        form = PhoneNumberForm({"phone": "+79261234567"})  # russian phone
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
My use case:
1. "US" region by default
2. "National" format by default
3. but in case of non "US" phone number - use INTERNATIONAL format

1, 2 works fine:
```python
PHONENUMBER_DEFAULT_REGION = 'US'
PHONENUMBER_DEFAULT_FORMAT = 'NATIONAL'
```

But if I'll submit an international phone number (e.g. "+79261234567") into django admin form for `PhoneNumberField` field - error will be shown that phone number is incorrect.
Internally, such PhoneNumber instance will be created:
```python
PhoneNumber(country_code=1, national_number=89261234567, extension=None, italian_leading_zero=None, number_of_leading_zeros=None, country_code_source=20, preferred_domestic_carrier_code='')
```

Which doesn't look correct: instead of `+7` region, `+1` was applied.

This patch tends to fix it.