### PR TITLE
Save should not raise `ValueError` on invalid phonenumber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ downloads
 eggs
 parts
 build
+venv
 *.egg-info
 *.egg
 .DS_Store

--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.core import checks
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import force_text
 from django.utils.translation import gettext_lazy as _

--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core import checks
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import force_text
 from django.utils.translation import gettext_lazy as _
@@ -80,9 +81,6 @@ class PhoneNumberField(models.CharField):
         if value:
             if not isinstance(value, PhoneNumber):
                 value = to_python(value)
-
-            if not value.is_valid():
-                raise ValueError("“%s” is not a valid phone number." % value.raw_input)
 
             format_string = getattr(settings, "PHONENUMBER_DB_FORMAT", "E164")
             fmt = PhoneNumber.format_map[format_string]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -213,14 +213,6 @@ class PhoneNumberFieldTestCase(TestCase):
         m = models.MandatoryPhoneNumber.objects.defer("phone_number").get(pk=m.pk)
         self.assertEqual(m.phone_number, self.test_number_1)
 
-    def test_filter_invalid(self):
-        models.NullablePhoneNumber.objects.create(phone_number=self.test_number_1)
-        models.NullablePhoneNumber.objects.create(phone_number="")
-        models.NullablePhoneNumber.objects.create(phone_number=None)
-        with self.assertRaises(ValueError) as cm:
-            models.NullablePhoneNumber.objects.filter(phone_number="123").exists()
-        self.assertEqual(force_text(cm.exception), "“123” is not a valid phone number.")
-
     def test_filter_int(self):
         models.NullablePhoneNumber.objects.create(phone_number=self.test_number_1)
         models.NullablePhoneNumber.objects.create(phone_number="")
@@ -245,38 +237,6 @@ class PhonenumerFieldAppTest(TestCase):
             models.TestModel.objects.all(),
             [(tm.pk, "", "+41524242424")],
             transform=phone_transform,
-        )
-
-    def test_create_invalid_number(self):
-        with self.assertRaises(ValueError) as cm:
-            models.TestModel.objects.create(phone="invalid")
-        self.assertEqual(
-            force_text(cm.exception), "“invalid” is not a valid phone number."
-        )
-
-    def test_save_invalid_number(self):
-        tm = models.TestModel.objects.create(phone="+1 604-333-4444")
-        tm.phone = "invalid"
-        with self.assertRaises(ValueError) as cm:
-            tm.save()
-        self.assertEqual(
-            force_text(cm.exception), "“invalid” is not a valid phone number."
-        )
-
-    def test_save_update_field_invalid_number(self):
-        tm = models.TestModel.objects.create(phone="+1 604-333-4444")
-        tm.phone = "invalid"
-        with self.assertRaises(ValueError) as cm:
-            tm.save(update_fields=["phone"])
-        self.assertEqual(
-            force_text(cm.exception), "“invalid” is not a valid phone number."
-        )
-
-    def test_update_to_invalid_number(self):
-        with self.assertRaises(ValueError) as cm:
-            models.TestModel.objects.update(phone="invalid")
-        self.assertEqual(
-            force_text(cm.exception), "“invalid” is not a valid phone number."
         )
 
     def test_save_blank_phone_to_database(self):


### PR DESCRIPTION
Save() should only raise `ValueError`s when the data to be stored
is incompatible with the raw field data. A string that contains
data that is not a valid phone number doesn't count as invalid,
and should be checked in clean(), not in save().

closes #334