### PR TITLE
Update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,41 +4,28 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-    - python: 3.7
-      env: TOXENV=black
-    - python: 3.7
-      env: TOXENV=flake8
-    - python: 3.7
-      env: TOXENV=isort
-    - python: 3.5
-      env: TOXENV=py35-dj111
-    - python: 3.6
-      env: TOXENV=py36-dj111
-    - python: 3.7
-      env: TOXENV=py37-dj111
-    - python: 3.5
-      env: TOXENV=py35-dj21
-    - python: 3.6
-      env: TOXENV=py36-dj21
-    - python: 3.7
-      env: TOXENV=py37-dj21
+    - env: TOXENV=black
+    - env: TOXENV=flake8
+    - env: TOXENV=isort
     - python: 3.5
       env: TOXENV=py35-dj22
     - python: 3.6
       env: TOXENV=py36-dj22
     - python: 3.7
       env: TOXENV=py37-dj22
+    - python: 3.8
+      env: TOXENV=py38-dj22
     - python: 3.6
       env: TOXENV=py36-dj30
     - python: 3.7
       env: TOXENV=py37-dj30
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-dj30
     - python: 3.6
       env: TOXENV=py36-djmaster
     - python: 3.7
       env: TOXENV=py37-djmaster
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-djmaster
   allow_failures:
     - env: TOXENV=py36-djmaster

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+
+**Backwards incompatible changes**
+
+* Drop support for end-of-life Django 1.11 and 2.2.
+
 4.0.0 (2019-12-06)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ platforms = OS Independent
 classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
-    Framework :: Django :: 1.11
-    Framework :: Django :: 2.1
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Intended Audience :: Developers
@@ -36,7 +34,7 @@ include_package_data = true
 python_requires = >=3.5
 install_requires =
     babel
-    Django >= 1.11.3
+    Django >= 2.2
 packages =
     phonenumber_field
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,7 @@ envlist =
     black
     flake8
     isort
-    py{35,36,37}-dj111
-    py{35,36,37}-dj21
-    py{35,36,37}-dj22
+    py{35,36,37,38}-dj22
     py{36,37,38}-dj30
     py{36,37,38}-djmaster
 minversion = 1.9
@@ -13,10 +11,9 @@ minversion = 1.9
 [testenv]
 deps =
     coverage
-    dj111: Django>=1.11,<1.12
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
-    dj30: Django>=3.0a1,<3.1
+    dj30: Django>=3.0,<3.1
     djmaster: https://github.com/django/django/archive/master.tar.gz
 extras = phonenumberslite
 commands =


### PR DESCRIPTION
- Use Python 3.8 final release.
- Add py38-dj22 entry. Support was added in Django 2.2.8.
- Remove specific version from Travis black, flake8, and isort. Travis
  now defaults to using Python 3.
- Remove Django 2.1 from testing. Django 2.1 is end-of-life since
  December 2, 2019. Removing it reduces testing resources and time.