### PR TITLE
Remove ignored by default flake8 rule from ignore list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ phonenumberslite =
     phonenumberslite >= 7.0.2
 
 [flake8]
-ignore = W503
 max-line-length = 88
 show-source = True
 


### PR DESCRIPTION
Duplicates the default configuration.