### PR TITLE
Make dependency on babel optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,14 @@ UNRELEASED
 * Add support for Django 3.1.
 * Fix rendering ``PhonePrefixSelect`` with ``initial`` passed to the
   constructor.
+* The Babel dependency is now optional.
 
 **Backwards incompatible changes**
 
 * Drop support for end-of-life Django 1.11 and 2.2.
+* As the Babel dependency is now optional, you must now install it to use
+  ``PhoneNumberPrefixWidget``. If you do not install it, an
+  ``ImproperlyConfigured`` exception will be raised when instantiated.
 
 4.0.0 (2019-12-06)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,14 @@ Included are:
 * ``PhoneNumberField``, a model field
 * ``PhoneNumberField``, a form field
 * ``PhoneNumberField``, a serializer field
-* ``PhoneNumberPrefixWidget``, a form widget for selecting a region code and entering a national number
+* ``PhoneNumberPrefixWidget``, a form widget for selecting a region code and
+  entering a national number. Requires the `Babel`_ package be installed.
 * ``PhoneNumberInternationalFallbackWidget``, a form widget that uses national numbers unless an
   international number is entered.  A ``PHONENUMBER_DEFAULT_REGION`` setting needs to be added
   to your Django settings in order to know which national number format to recognize.  The
   setting is a string containing an ISO-3166-1 two-letter country code.
 
+.. _`Babel`: https://pypi.org/project/Babel/
 
 Installation
 ============

--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -1,5 +1,5 @@
-from babel import Locale
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.forms import Select, TextInput
 from django.forms.widgets import MultiWidget
 from django.utils import translation
@@ -12,15 +12,25 @@ from phonenumbers.phonenumberutil import (
 
 from phonenumber_field.phonenumber import PhoneNumber
 
+try:
+    import babel
+except ModuleNotFoundError:
+    babel = None
+
 
 class PhonePrefixSelect(Select):
     initial = None
 
     def __init__(self, initial=None):
+        if babel is None:
+            raise ImproperlyConfigured(
+                "The PhonePrefixSelect widget requires the babel package be installed."
+            )
+
         choices = [("", "---------")]
         language = translation.get_language() or settings.LANGUAGE_CODE
         if language:
-            locale = Locale(translation.to_locale(language))
+            locale = babel.Locale(translation.to_locale(language))
             if not initial:
                 region = getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
                 initial = region

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.5
 install_requires =
-    babel
     Django >= 2.2
 packages =
     phonenumber_field

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ minversion = 1.9
 
 [testenv]
 deps =
+    babel
     coverage
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0


### PR DESCRIPTION
As far as Python packages go, babel is quite large weighing in at 29M.
This is due to it containing a very large amount of locale data.

As babel is only used by the PhonePrefixSelect, which isn't used by all
library users, make the dependency optional.

For library users that vendor or bundle django-phonenumber-field and its
dependencies, this greatly cuts down on the final size.