### PR TITLE
Remove unnecessary `if language` check

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -29,19 +29,18 @@ class PhonePrefixSelect(Select):
 
         choices = [("", "---------")]
         language = translation.get_language() or settings.LANGUAGE_CODE
-        if language:
-            locale = babel.Locale(translation.to_locale(language))
-            if not initial:
-                region = getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
-                initial = region
-            for prefix, values in _COUNTRY_CODE_TO_REGION_CODE.items():
-                prefix = "+%d" % prefix
-                if initial and initial in values:
-                    self.initial = prefix
-                for country_code in values:
-                    country_name = locale.territories.get(country_code)
-                    if country_name:
-                        choices.append((prefix, "{} {}".format(country_name, prefix)))
+        locale = babel.Locale(translation.to_locale(language))
+        if not initial:
+            region = getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
+            initial = region
+        for prefix, values in _COUNTRY_CODE_TO_REGION_CODE.items():
+            prefix = "+%d" % prefix
+            if initial and initial in values:
+                self.initial = prefix
+            for country_code in values:
+                country_name = locale.territories.get(country_code)
+                if country_name:
+                    choices.append((prefix, "{} {}".format(country_name, prefix)))
         super().__init__(choices=sorted(choices, key=lambda item: item[1]))
 
     def get_context(self, name, value, attrs):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,6 +3,7 @@ from django import forms
 from django.core import checks
 from django.db.models import Model
 from django.test import SimpleTestCase, TestCase, override_settings
+from django.utils import translation
 from django.utils.encoding import force_text
 from phonenumbers import phonenumberutil
 
@@ -599,3 +600,11 @@ class PhoneNumberPrefixWidgetTest(SimpleTestCase):
         rendered = PhoneNumberPrefixWidget().render("", "")
         self.assertIn('<option value="" selected>---------</option>', rendered)
         self.assertIn('<option value="+86">China +86</option', rendered)
+
+    @override_settings(USE_I18N=True)
+    def test_after_translation_deactivate_all(self):
+        translation.deactivate_all()
+        rendered = PhoneNumberPrefixWidget().render("", "")
+        self.assertIn(
+            '<select name="_0"><option value="" selected>---------</option>', rendered
+        )


### PR DESCRIPTION
settings.LANGUAGE_CODE must be set in a Django application, so this
value is never empty.