### PR TITLE
 Simplify isort config using 'profile = black'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,4 @@ max-line-length = 88
 show-source = True
 
 [isort]
-combine_as_imports = True
-default_section = THIRDPARTY
-include_trailing_comma = True
-known_first_party = phonenumber_field
-line_length = 88
-multi_line_output = 3
+profile = black

--- a/tox.ini
+++ b/tox.ini
@@ -44,5 +44,5 @@ skip_install = true
 commands =
     isort --check-only --diff .
 deps =
-    isort>=5.0.1
+    isort>=5.0.2
 skip_install = true


### PR DESCRIPTION
isort now has builtin support for black through its "profiles" feature.

https://timothycrosley.github.io/isort/docs/configuration/profiles/#black