### PR TITLE
Update CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ CHANGELOG
 
 **Backwards incompatible changes**
 
-* Drop support for end-of-life Django 1.11 and 2.2.
+* Drop support for end-of-life Django 1.11 and 2.1.
 * As the Babel dependency is now optional, you must now install it to use
   ``PhoneNumberPrefixWidget``. If you do not install it, an
   ``ImproperlyConfigured`` exception will be raised when instantiated.


### PR DESCRIPTION
Corrected the release notes to show that Django 2.2 is still okay to use as it's not EOL whereas Django 2.1 is