### PR TITLE
Update CHANGELOG.rst - Fix for issue #382

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ CHANGELOG
 
 **Backwards incompatible changes**
 
-* Drop support for end-of-life Django 1.11 and 2.2.
+* Drop support for end-of-life Django 1.11 and 2.1.
 * As the Babel dependency is now optional, you must now install it to use
   ``PhoneNumberPrefixWidget``. If you do not install it, an
   ``ImproperlyConfigured`` exception will be raised when instantiated.


### PR DESCRIPTION
Corrected the change log for 5.0.0 which incorrectly said it dropped support for Django 2.2 stating it was EOL when it's not EOL as it's an LTS release. This is confirmed in the setup files.