### PR TITLE
Fix EOL versions in 5.0.0 changelog, refs #382

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ CHANGELOG
 
 **Backwards incompatible changes**
 
-* Drop support for end-of-life Django 1.11 and 2.2.
+* Drop support for end-of-life Django 1.11 and < 2.2.
 * As the Babel dependency is now optional, you must now install it to use
   ``PhoneNumberPrefixWidget``. If you do not install it, an
   ``ImproperlyConfigured`` exception will be raised when instantiated.


### PR DESCRIPTION
Django 2.2 is still supported and working. It should not be listed as support dropped.
Listed as minimum requirement according to setup.cfg and tested against according to tox.ini