### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+
+**Backwards incompatible changes**
+
+* Drop support for Python 3.5
+
 5.0.0 (2020-08-17)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -32,7 +31,7 @@ classifiers =
 [options]
 zip_safe = false
 include_package_data = true
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     Django >= 2.2
 packages =

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,17 +33,20 @@ class PhoneNumberFieldTestCase(TestCase):
 
     def test_str_for_valid_number(self):
         self.assertEqual(
-            str(PhoneNumber.from_string(self.test_number_1)), self.test_number_1,
+            str(PhoneNumber.from_string(self.test_number_1)),
+            self.test_number_1,
         )
 
     def test_str_for_invalid_number(self):
         self.assertEqual(
-            str(to_python("invalid")), "invalid",
+            str(to_python("invalid")),
+            "invalid",
         )
 
     def test_repr_for_invalid_number(self):
         self.assertEqual(
-            repr(to_python("invalid")), "InvalidPhoneNumber(raw_input=invalid)",
+            repr(to_python("invalid")),
+            "InvalidPhoneNumber(raw_input=invalid)",
         )
 
     def test_repr_for_valid_number(self):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     black
     flake8
     isort
-    py{35,36,37,38}-dj22
+    py{36,37,38}-dj22
     py{36,37,38}-dj30
     py{36,37,38}-dj31
     py{36,37,38}-djmaster
@@ -28,7 +28,7 @@ commands =
 [testenv:black]
 basepython = python3
 commands =
-    black --target-version=py35 --check --diff .
+    black --target-version=py36 --check --diff .
 deps =
     black
 skip_install = true


### PR DESCRIPTION
Python 3.5 end of life was Sept 5th, 2020.
https://www.python.org/downloads/release/python-3510/