### PR TITLE
Replace deprecated force_text with force_str

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core import checks
 from django.db import models
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from phonenumber_field import formfields
@@ -70,7 +70,7 @@ class PhoneNumberField(models.CharField):
         try:
             validate_region(self.region)
         except ValueError as e:
-            return [checks.Error(force_text(e), obj=self)]
+            return [checks.Error(force_str(e), obj=self)]
         return []
 
     def get_prep_value(self, value):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,7 +3,7 @@ from django import forms
 from django.core import checks
 from django.db.models import Model
 from django.test import TestCase, override_settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from phonenumbers import phonenumberutil
 
 from phonenumber_field import formfields, modelfields
@@ -409,7 +409,7 @@ class RegionPhoneNumberFormFieldTest(TestCase):
             formfields.PhoneNumberField(region="invalid")
 
         self.assertTrue(
-            force_text(cm.exception).startswith("“invalid” is not a valid region code.")
+            force_str(cm.exception).startswith("“invalid” is not a valid region code.")
         )
 
     def test_error_message_nationalize_example(self):


### PR DESCRIPTION
The `force_text` helper will be removed in Django 4.0.

https://github.com/django/django/commit/d55e88292723764a16f0689c73bc7e739dfa6047