### PR TITLE
Set DEFAULT_AUTO_FIELD for the test project

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 SECRET_KEY = "secrekey"
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/releases/3.2/#customizing-type-of-auto-created-primary-keys

Avoid warnings on Django master:

```
tests.TestModelPhoneNU: (models.W042) Auto-created primary key used when not defining a primary key type, by default
 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a s
ubclass of AutoField, e.g. 'django.db.models.BigAutoField
```