### PR TITLE
Remove Django 2.1 from github actions matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
           - 3.7
           - 3.8
         tox-environment:
-          - dj21
           - dj22
           - dj30
           - dj31


### PR DESCRIPTION
It was left in the github actions in
05cc2a7c6fe9a657fb9b135b8fe06eb9b165ce2b to increase similarity with the
old travis.yml. Since the Django 2.1 is not supported, it should be
removed from the test matrix.