### PR TITLE
Use default Python version to finish coveralls build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,6 @@ jobs:
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
 
       - name: Install coveralls
         run: python -m pip install coveralls


### PR DESCRIPTION
The python version does not matter for that build, use the default.