### PR TITLE
Don’t package .gitignore

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include README.rst
 include tox.ini
 recursive-include phonenumber_field/locale django.mo django.po
 recursive-include tests *.py
+
+exclude .gitignore


### PR DESCRIPTION
File is specific to version control and should not be distributed.