### PR TITLE
Use setuptools_scm to get the version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ tests/tmp/
 htmlcov/
 share/
 .coverage*
+# Written by setuptools_scm.
+phonenumber_field/version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,3 @@
-include LICENSE
-include README.rst
-include tox.ini
-recursive-include phonenumber_field/locale django.mo django.po
-recursive-include tests *.py
+exclude .gitignore
+exclude sonar-project.properties
+prune .github

--- a/phonenumber_field/__init__.py
+++ b/phonenumber_field/__init__.py
@@ -1,1 +1,7 @@
-__version__ = "5.0.0"
+try:
+    from .version import version
+except ImportError:
+    # The version module is written by setuptools_scm.
+    __version__ = None
+else:
+    __version__ = version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "setuptools_scm[toml]>=3.4",
+]
+
+[tool.setuptools_scm]
+write_to = "phonenumber_field/version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = django-phonenumber-field
-version = attr: phonenumber_field.__version__
 description = An international phone number field for django models.
 long_description = file: README.rst
 url = https://github.com/stefanfoulis/django-phonenumber-field


### PR DESCRIPTION
Follow recommendation from https://jazzband.co/about/releases#packaging.

Files tracked with the version control system are included in the source
distribution. That avoids the error-prone listing of files in
MANIFEST.in.

Don’t package the .github directory and sonar-project.properties, they
contain CI configuration for the project and should not be distributed.

Don’t package .gitignore, it is specific to version control and should
not be distributed.

Refs #224