### PR TITLE
Allow sorting PhoneNumber instances in Python

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ CHANGELOG
 UNRELEASED
 ----------
 
+* Allow sorting ``PhoneNumber``\ s from Python
 * Add support for Python 3.9 and Django 3.2
 * Add Argentinian, Bulgarian, Indonesian, Ukrainian translations
 * Update Esperanto and European Spanish translations

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -519,3 +519,46 @@ class RegionPhoneNumberModelFieldTest(TestCase):
         )
         self.assertEqual(phonenumbers.parse(ALGERIAN_PHONE_NUMBER), m.phone_number)
         self.assertEqual(ALGERIAN_PHONE_NUMBER, m.phone_number)
+
+
+class PhoneNumberOrdering(TestCase):
+    def test_ordering(self):
+        phone1 = PhoneNumber.from_string("+33600000000")
+        phone2 = PhoneNumber.from_string("+33600000001")
+        self.assertLess(phone1, phone2)
+        # Ordering is total.
+        self.assertGreater(phone2, phone1)
+        self.assertLessEqual(phone1, phone1)
+        self.assertGreaterEqual(phone1, phone1)
+        self.assertEqual(phone1, phone1)
+
+    def test_ordering_with_phonenumbers(self):
+        phone1 = PhoneNumber.from_string("+33600000000")
+        phone2 = phonenumbers.parse("+33600000001")
+        self.assertLess(phone1, phone2)
+
+    def test_ordering_contains_None(self):
+        phone1 = PhoneNumber.from_string("+33600000000")
+        msg = "'<' not supported between instances of " "'PhoneNumber' and 'NoneType'"
+        for assertion in [
+            self.assertLess,
+            self.assertLessEqual,
+            self.assertGreater,
+            self.assertGreaterEqual,
+        ]:
+            with self.subTest(assertion):
+                with self.assertRaisesMessage(TypeError, msg):
+                    assertion(phone1, None)
+
+    def test_ordering_with_invalid_value(self):
+        phone1 = PhoneNumber.from_string("+33600000000")
+        invalid = PhoneNumber.from_string("+1000000000")
+        invalid_phonenumbers = phonenumbers.parse("+1000000000")
+        for number in [invalid, invalid_phonenumbers]:
+            with self.subTest(number):
+                for p1, p2 in [[phone1, number], [number, phone1]]:
+                    with self.subTest([p1, p2]):
+                        with self.assertRaisesRegex(
+                            ValueError, r"^Invalid phone number: "
+                        ):
+                            self.assertLess(p1, p2)


### PR DESCRIPTION
While the use case is not obvious, databases allow sorting by a phone
number field. Users can reasonably expect to sort that data in Python as
well.

The __lt__ method expects an homogeneous collection of PhoneNumber
instances, or possibly `phonenumbers.PhoneNumber`.

The database string representation of PhoneNumber is used for the
comparison, to reasonably match the sorting that the database would
perform. It may differ based on the database collation.

Fix #371