### PR TITLE
Set long_description_content_type in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = django-phonenumber-field
 description = An international phone number field for django models.
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 url = https://github.com/stefanfoulis/django-phonenumber-field
 license = MIT
 author = Stefan Foulis


### PR DESCRIPTION
Avoids warning:
```
$ twine check dist/*
Checking dist/django-phonenumber-field-5.0.1.dev38+gf3e66d8.tar.gz: PASSED, with warnings
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
```