### PR TITLE
Ignore coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ lib/
 include/
 tests/tmp/
 *.coverage
+/coverage-reports
 htmlcov/
 share/
 .coverage*


### PR DESCRIPTION
Running tox locally generates a coverage-reports directory. It is the
result of a build and can safely be ignored.