### PR TITLE
Verify translations are compiled in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,11 @@ jobs:
       TOXENV: ${{ matrix.tox-environment }}
 
     steps:
+      - name: Install gettext
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext
+
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 exclude .gitignore
+exclude check-translations
 exclude sonar-project.properties
 prune .github

--- a/check-translations
+++ b/check-translations
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+import django
+from django.core.management import call_command
+
+
+def main():
+    kwargs = {} if django.VERSION < (3,) else {"ignore": ".tox"}
+    with open(os.devnull, "w") as devnull:
+        call_command("compilemessages", **kwargs, stdout=devnull)
+
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    stdout = result.stdout.decode()
+    if stdout != "":
+        print(
+            f"Unexpected changes found in the workspace:\n\n{stdout}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    assert result.stderr is None
+
+
+if __name__ == "__main__":
+    os.environ["DJANGO_SETTINGS_MODULE"] = "tests.settings"
+    django.setup()
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands =
     coverage xml -o coverage-reports/coverage.xml
     coverage html -d coverage-reports/html
     coverage report
+    python check-translations
 
 [testenv:black]
 basepython = python3


### PR DESCRIPTION
Avoids manually running compilemessages locally to check if the compiled 
message files are up to date.