### PR TITLE
Drop deprecated setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "wheel",
     "setuptools_scm[toml]>=3.4",
 ]
+build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.setuptools_scm]
 write_to = "phonenumber_field/version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     dj31
     dj32
     djmain
+isolated_build = true
 minversion = 1.9
 
 [testenv]


### PR DESCRIPTION
Prefer the declarative syntax of setup.cfg. To package the project:

```
pip install build
python -m build
```

https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html