### PR TITLE
Prefer GitHub releases over the CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,14 @@
 CHANGELOG
 =========
 
-UNRELEASED
-----------
+**Releases are now tracked using the `GitHub releases
+<https://github.com/stefanfoulis/django-phonenumber-field/releases>`_. This
+document remains for historical purposes.**
 
-* Set the default region of ``phonenumber_field.formfields.PhoneNumberField``
-  to ``PHONENUMER_DEFAULT_REGION``.
-* Use PHONENUMBER_DEFAULT_REGION for example phone number in form field errors.
+6.1.0 (2022-01-12)
+------------------
+* Make ``formfields.PhoneNumberField`` honor ``PHONENUMBER_DEFAULT_REGION``
+* Use ``PHONENUMBER_DEFAULT_REGION`` for example phone number in form field errors.
 * Add support for Django 4.0
 * Add Persian (farsi) translations.
 * Update uk_AR translations


### PR DESCRIPTION
Instead of keeping a changelog (which is often forgotten), use the
GitHub releases feature. It generates the changelog from commit history,
thanks contributors and is richer than the changelog files, because it
allows comparing releases, listing commits in a specific release,
downloading artifacts, and more…