### PR TITLE
Remove `maxlength` attribute for html5 compliance

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -43,6 +43,8 @@ class PhonePrefixSelect(Select):
         super().__init__(choices=sorted(choices, key=lambda item: item[1]))
 
     def get_context(self, name, value, attrs):
+        attrs = (attrs or {}).copy()
+        attrs.pop("maxlength", None)
         return super().get_context(name, value or self.initial, attrs)
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -33,6 +33,12 @@ class PhoneNumberPrefixWidgetTest(SimpleTestCase):
             '<select name="_0"><option value="" selected>---------</option>', rendered
         )
 
+    def test_maxlength_not_in_select(self):
+        # Regression test for #490
+        widget = PhoneNumberPrefixWidget()
+        html = widget.render(name="widget", value=None, attrs={"maxlength": 32})
+        self.assertIn('<select name="widget_0">', html)
+
 
 class PhoneNumberInternationalFallbackWidgetTest(SimpleTestCase):
     def test_fallback_widget_switches_between_national_and_international(self):


### PR DESCRIPTION
Pages that use `PhonePrefixSelect` do not validate with [vnu validator](https://validator.github.io/validator/) because `<select>` tag is rendered with `maxlength` attribute which makes no sense for that tag. With this PR we just inspect context and pop `maxlength` attribute if it is present.