### PR TITLE
PhoneNumberPrefixWidget improvement for regions sharing same country prefix

### DIFF
--- a/phonenumber_field/validators.py
+++ b/phonenumber_field/validators.py
@@ -1,12 +1,12 @@
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
-from phonenumber_field.phonenumber import to_python
+from phonenumber_field.phonenumber import PhoneNumber, to_python
 
 
 def validate_international_phonenumber(value):
     phone_number = to_python(value)
-    if phone_number and not phone_number.is_valid():
+    if isinstance(phone_number, PhoneNumber) and not phone_number.is_valid():
         raise ValidationError(
             _("The phone number entered is not valid."), code="invalid_phone_number"
         )

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,8 +1,10 @@
+import phonenumbers
+from django import forms
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase, override_settings
 from django.utils import translation
 
-from phonenumber_field import widgets
+from phonenumber_field import formfields, widgets
 from phonenumber_field.phonenumber import PhoneNumber
 from phonenumber_field.widgets import (
     PhoneNumberInternationalFallbackWidget,
@@ -25,22 +27,47 @@ class PhonePrefixSelectTest(SimpleTestCase):
         super().tearDown()
 
 
+def example_number(region_code: str) -> PhoneNumber:
+    number = phonenumbers.example_number(region_code)
+    e164 = phonenumbers.format_number(number, phonenumbers.PhoneNumberFormat.E164)
+    return PhoneNumber.from_string(e164, region=region_code)
+
+
+EXAMPLE_NUMBERS = (
+    example_number("US"),
+    example_number("CA"),
+    example_number("GB"),
+    example_number("GG"),
+    example_number("PL"),
+    example_number("IT"),
+)
+
+
 class PhoneNumberPrefixWidgetTest(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        class TestForm(forms.Form):
+            phone = formfields.PhoneNumberField(widget=PhoneNumberPrefixWidget)
+
+        cls.form_class = TestForm
+
     def test_initial(self):
         rendered = PhoneNumberPrefixWidget(initial="CN").render("", "")
         self.assertIn('<option value="">---------</option>', rendered)
-        self.assertIn('<option value="+86" selected>China +86</option>', rendered)
+        self.assertIn('<option value="CN" selected>China +86</option>', rendered)
 
     @override_settings(PHONENUMBER_DEFAULT_REGION="CN")
     def test_uses_default_region_as_initial(self):
         rendered = PhoneNumberPrefixWidget().render("", "")
         self.assertIn('<option value="">---------</option>', rendered)
-        self.assertIn('<option value="+86" selected>China +86</option>', rendered)
+        self.assertIn('<option value="CN" selected>China +86</option>', rendered)
 
     def test_no_initial(self):
         rendered = PhoneNumberPrefixWidget().render("", "")
         self.assertIn('<option value="" selected>---------</option>', rendered)
-        self.assertIn('<option value="+86">China +86</option>', rendered)
+        self.assertIn('<option value="CN">China +86</option>', rendered)
 
     @override_settings(USE_I18N=True)
     def test_after_translation_deactivate_all(self):
@@ -48,6 +75,128 @@ class PhoneNumberPrefixWidgetTest(SimpleTestCase):
         rendered = PhoneNumberPrefixWidget().render("", "")
         self.assertIn(
             '<select name="_0"><option value="" selected>---------</option>', rendered
+        )
+
+    def test_value_from_datadict(self):
+        tests = [
+            (
+                {
+                    "phone_0": phonenumbers.region_code_for_number(number),
+                    "phone_1": phonenumbers.national_significant_number(number),
+                },
+                number,
+            )
+            for number in EXAMPLE_NUMBERS
+        ]
+
+        for data, expected in tests:
+            with self.subTest(data):
+                form = self.form_class(data=data)
+                self.assertIs(form.is_valid(), True)
+                self.assertEqual(form.cleaned_data, {"phone": expected})
+
+    def test_empty_region(self):
+        invalid_national_number = "8876543210"
+        form = self.form_class(data={"phone_0": "", "phone_1": invalid_national_number})
+        self.assertFalse(form.is_valid())
+        rendered_form = form.as_ul()
+        self.assertInHTML(
+            '<ul class="errorlist"><li>Enter a valid phone number '
+            "(e.g. +12125552368).</li></ul>",
+            rendered_form,
+        )
+        # Keeps national number input.
+        self.assertInHTML(
+            f'<input type="text" name="phone_1" '
+            f'value="{invalid_national_number}" required id="id_phone_1">',
+            rendered_form,
+            count=1,
+        )
+        self.assertInHTML(
+            '<option value="" selected>---------</option>',
+            rendered_form,
+            count=1,
+        )
+
+    def test_empty_national_number(self):
+        form = self.form_class(data={"phone_0": "CA", "phone_1": ""})
+        self.assertFalse(form.is_valid())
+        rendered_form = form.as_ul()
+        self.assertInHTML(
+            '<ul class="errorlist"><li>The phone number entered is not valid.'
+            "</li></ul>",
+            rendered_form,
+        )
+        self.assertInHTML(
+            '<input type="text" name="phone_1" required id="id_phone_1">',
+            rendered_form,
+            count=1,
+        )
+        self.assertInHTML(
+            '<option value="CA" selected>Canada +1</option>',
+            rendered_form,
+            count=1,
+        )
+
+    def test_no_region(self):
+        form = self.form_class(data={"phone_1": "654321"})
+        self.assertFalse(form.is_valid())
+        rendered_form = form.as_ul()
+        self.assertInHTML(
+            '<ul class="errorlist"><li>Enter a valid phone number '
+            "(e.g. +12125552368).</li></ul>",
+            rendered_form,
+        )
+        self.assertInHTML(
+            '<input type="text" name="phone_1" value="654321" '
+            'required id="id_phone_1">',
+            rendered_form,
+            count=1,
+        )
+        self.assertInHTML(
+            '<option value="" selected>---------</option>',
+            rendered_form,
+            count=1,
+        )
+
+    def test_no_national_number(self):
+        form = self.form_class(data={"phone_0": "CA"})
+        self.assertFalse(form.is_valid())
+        rendered_form = form.as_ul()
+        self.assertInHTML(
+            '<ul class="errorlist"><li>The phone number entered is not valid.'
+            "</li></ul>",
+            rendered_form,
+        )
+        self.assertInHTML(
+            '<input type="text" name="phone_1" required id="id_phone_1">',
+            rendered_form,
+            count=1,
+        )
+        self.assertInHTML(
+            '<option value="CA" selected>Canada +1</option>',
+            rendered_form,
+            count=1,
+        )
+
+    def test_keeps_region_with_invalid_national_number(self):
+        form = self.form_class(data={"phone_0": "CA", "phone_1": "0000"})
+        self.assertFalse(form.is_valid())
+        rendered_form = str(form)
+        self.assertInHTML(
+            '<ul class="errorlist"><li>Enter a valid phone number (e.g. +12125552368).'
+            "</li></ul>",
+            rendered_form,
+        )
+        self.assertInHTML(
+            '<input type="text" name="phone_1" value="0000" required id="id_phone_1">',
+            rendered_form,
+            count=1,
+        )
+        self.assertInHTML(
+            '<option value="CA" selected>Canada +1</option>',
+            rendered_form,
+            count=1,
         )
 
     def test_maxlength_not_in_select(self):


### PR DESCRIPTION
As promised in #251 this PR improves `PhoneNumberPrefixWidget` handling for regions sharing the same country prefix. Current behavior does not follow requirements for `Select.Choices`. Choices should be indexed by [unique](https://docs.djangoproject.com/en/4.0/ref/models/fields/#enumeration-types) values and this requirement was not met for 12 country prefixes.

Fixes #133
Fixes #251
Fixes #489