### PR TITLE
Drop Django 3.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
           - '3.10'
         tox-environment:
           - dj22
-          - dj31
           - dj32
         include:
           - python-version: 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Intended Audience :: Developers

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     flake8
     isort
     dj22
-    dj31
     dj32
     djmain
 isolated_build = true
@@ -15,7 +14,6 @@ deps =
     babel
     coverage
     dj22: Django>=2.2,<3.0
-    dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Version reached its end of life.
https://www.djangoproject.com/download/#supported-versions