### PR TITLE
Render input value with PhoneNumberPrefixWidget on form errors

### DIFF
--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -6,19 +6,27 @@ from django.forms.fields import CharField
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 
-from phonenumber_field.phonenumber import PhoneNumber, to_python, validate_region
+from phonenumber_field.phonenumber import to_python, validate_region
 from phonenumber_field.validators import validate_international_phonenumber
+from phonenumber_field.widgets import PhoneNumberInternationalFallbackWidget
 
 
 class PhoneNumberField(CharField):
     default_validators = [validate_international_phonenumber]
+    widget = PhoneNumberInternationalFallbackWidget
 
-    def __init__(self, *args, region=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.widget.input_type = "tel"
-
+    def __init__(self, *args, region=None, widget=None, **kwargs):
         validate_region(region)
         self.region = region or getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
+
+        if widget is None:
+            try:
+                widget = self.widget(region=self.region)
+            except TypeError:
+                widget = self.widget()
+
+        super().__init__(*args, widget=widget, **kwargs)
+        self.widget.input_type = "tel"
 
         if "invalid" not in self.error_messages:
             if self.region:
@@ -36,24 +44,6 @@ class PhoneNumberField(CharField):
             self.error_messages["invalid"] = format_lazy(
                 error_message, example_number=example_number
             )
-
-    def prepare_value(self, value):
-        if self.region and value not in validators.EMPTY_VALUES:
-            phone_number = (
-                value
-                if isinstance(value, PhoneNumber)
-                else to_python(value, region=self.region)
-            )
-            try:
-                phone_region_codes = phonenumbers.data._COUNTRY_CODE_TO_REGION_CODE[
-                    phone_number.country_code
-                ]
-            except KeyError:
-                pass
-            else:
-                if self.region in phone_region_codes:
-                    value = phone_number.as_national
-        return value
 
     def to_python(self, value):
         phone_number = to_python(value, region=self.region)

--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -9,6 +9,7 @@ from phonenumbers.phonenumberutil import (
     COUNTRY_CODE_TO_REGION_CODE,
     national_significant_number,
     region_code_for_number,
+    region_codes_for_country_code,
 )
 
 from phonenumber_field.phonenumber import PhoneNumber, to_python
@@ -109,12 +110,21 @@ class PhoneNumberInternationalFallbackWidget(TextInput):
         self.region = region
         super().__init__(attrs)
 
+    def value_from_datadict(self, data, files, name):
+        phone_number_str = super().value_from_datadict(data, files, name)
+
+        if phone_number_str is None:
+            phone_number_str = ""
+        return to_python(phone_number_str, region=self.region)
+
     def format_value(self, value):
         if isinstance(value, PhoneNumber):
-            number_region = region_code_for_number(value)
-            if self.region != number_region:
-                formatter = PhoneNumberFormat.INTERNATIONAL
-            else:
-                formatter = PhoneNumberFormat.NATIONAL
-            return value.format_as(formatter)
+            if value.is_valid():
+                region_codes = region_codes_for_country_code(value.country_code)
+                formatter = (
+                    PhoneNumberFormat.NATIONAL
+                    if self.region in region_codes
+                    else PhoneNumberFormat.INTERNATIONAL
+                )
+                return value.format_as(formatter)
         return super().format_value(value)

--- a/tests/test_formfields.py
+++ b/tests/test_formfields.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase, override_settings
 from django.utils.functional import lazy
 
 from phonenumber_field.formfields import PhoneNumberField
+from phonenumber_field.widgets import PhoneNumberPrefixWidget
 
 ALGERIAN_PHONE_NUMBER = "+213799136332"
 
@@ -75,3 +76,91 @@ class PhoneNumberFormFieldTest(SimpleTestCase):
             side_effect=lazy(fail_gettext, str),
         ):
             PhoneNumberField()
+
+    @override_settings(PHONENUMBER_DEFAULT_REGION="FR")
+    def test_input_not_cleared_on_other_field_error(self):
+        class PhoneNumberForm(forms.Form):
+            name = forms.CharField(min_length=4, max_length=100)
+            number = PhoneNumberField(required=False, widget=PhoneNumberPrefixWidget())
+
+        form = PhoneNumberForm({"name": "a", "number_0": "FR", "number_1": "612345678"})
+        self.assertIs(form.is_valid(), False)
+        self.assertEqual(
+            form.errors,
+            {"name": ["Ensure this value has at least 4 characters (it has 1)."]},
+        )
+        self.maxDiff = None
+        form_html = form.as_p()
+        self.assertInHTML(
+            """
+            <ul class="errorlist">
+                <li>
+                Ensure this value has at least 4 characters (it has 1).
+                </li>
+            </ul>
+            <p>
+                <label for="id_name">Name:</label>
+                <input
+                   id="id_name"
+                   maxlength="100"
+                   minlength="4"
+                   name="name"
+                   required
+                   type="text"
+                   value="a">
+            </p>
+            """,
+            form_html,
+            count=1,
+        )
+        self.assertInHTML(
+            '<option selected value="FR">France +33</option>',
+            form_html,
+            count=1,
+        )
+        self.assertInHTML(
+            '<input id="id_number_1" name="number_1" type="text" value="612345678">',
+            form_html,
+            count=1,
+        )
+
+    def test_override_widget(self):
+        class MyPhoneNumberField(PhoneNumberField):
+            widget = forms.TextInput
+
+        class TestForm(forms.Form):
+            phone = MyPhoneNumberField(region="FR")
+
+        form = TestForm({"phone": "+33612345678"})
+        self.assertIs(form.is_valid(), True)
+        self.assertHTMLEqual(
+            form.as_p(),
+            """
+            <p>
+            <label for="id_phone">Phone:</label>
+            <input id="id_phone" name="phone" required type="tel" value="+33612345678">
+            </p>
+            """,
+        )
+
+    @override_settings(PHONENUMBER_DEFAULT_REGION="FR")
+    def test_widget_uses_default_region(self):
+        class TestForm(forms.Form):
+            phone = PhoneNumberField()
+
+        form = TestForm({"phone": "+33612345678"})
+        self.assertIs(form.is_valid(), True)
+        self.assertHTMLEqual(
+            form.as_p(),
+            """
+            <p>
+            <label for="id_phone">Phone:</label>
+            <input
+               id="id_phone"
+               name="phone"
+               required
+               type="tel"
+               value="06 12 34 56 78">
+            </p>
+            """,
+        )

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -229,8 +229,10 @@ class PhoneNumberInternationalFallbackWidgetTest(SimpleTestCase):
         region = "GB"
         number_string = "01606 751 78"
         number = PhoneNumber.from_string(number_string, region=region)
-        gb_widget = PhoneNumberInternationalFallbackWidget(region="GB")
-        de_widget = PhoneNumberInternationalFallbackWidget(region="DE")
+        gb_widget = PhoneNumberInternationalFallbackWidget()
+        gb_widget.region = "GB"
+        de_widget = PhoneNumberInternationalFallbackWidget()
+        de_widget.region = "DE"
         self.assertHTMLEqual(
             gb_widget.render("number", number),
             '<input name="number" type="text" value="01606 75178" />',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -552,7 +552,7 @@ class RegionPhoneNumberModelFieldTest(TestCase):
             "<input "
             'type="tel" '
             'name="phone" '
-            'value="+32468547825" '
+            'value="+32 468 54 78 25" '
             'maxlength="128" '
             'id="id_phone">'
             "</p>",
@@ -568,7 +568,7 @@ class RegionPhoneNumberModelFieldTest(TestCase):
             "<input "
             'type="tel" '
             'name="phone" '
-            'value="+32468547825" '
+            'value="+32 468 54 78 25" '
             'maxlength="128" '
             'id="id_phone">'
             "</p>",


### PR DESCRIPTION
The phone number input field was incorrectly cleared when:
- a form has an error on another field, and
- the phone number field is displayed with PhoneNumberPrefixWidget, and
- the phone number region is the default region.

That behavior was caused by 005769cf39323e5b23710783f45befb546672cd6,
which incorrectly used `prepare_value()` to transform a PhoneNumber
instance to an str (the phone number in national format). By doing so,
information was lost and the decompress() method of
PhoneNumberPrefixWidget unexpectedly received an str.

The phone number value is now always a PhoneNumber instance. It’s up to
the widget to format that value.
To retain the behavior of showing national phone numbers in the national
format by default, the formfields.PhoneNumberField widget is now
PhoneNumberInternationalFallbackWidget.

PhoneNumberInternationalFallbackWidget behavior was updated to match the
previous implementation of prepare_value: the number is displayed in
national format if its country code matches the country code of the
configured region.
It now represents its value as a PhoneNumber, a richer type than `str`,
which facilitates the custom display logic.

Fixes #518 