### PR TITLE
Handle primitive types in serializerfields

### DIFF
--- a/phonenumber_field/serializerfields.py
+++ b/phonenumber_field/serializerfields.py
@@ -9,7 +9,8 @@ class PhoneNumberField(serializers.CharField):
     default_error_messages = {"invalid": _("Enter a valid phone number.")}
 
     def to_internal_value(self, data):
-        phone_number = to_python(data)
+        str_value = super().to_internal_value(data)
+        phone_number = to_python(str_value)
         if phone_number and not phone_number.is_valid():
             raise ValidationError(self.error_messages["invalid"])
         return phone_number

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,6 +1,8 @@
 from django.test import SimpleTestCase
 from rest_framework import serializers
 
+from phonenumber_field.serializerfields import PhoneNumberField
+
 from .models import OptionalPhoneNumber
 
 
@@ -16,3 +18,10 @@ class PhoneNumberSerializerTest(SimpleTestCase):
                 s = PhoneNumberSerializer(data=data)
                 self.assertIs(s.is_valid(), True)
                 self.assertEqual(s.data, {})
+
+    def test_int(self):
+        class PhoneNumberSerializer(serializers.Serializer):
+            phone = PhoneNumberField()
+
+        s = PhoneNumberSerializer(data={"phone": 1})
+        self.assertIs(s.is_valid(), False)


### PR DESCRIPTION
Avoid crashes because the to_python helper expects data to be provided
as string.

Fixes #265 
Fixes #474 