### PR TITLE
Evolve PhoneNumberInternationalWidget to RegionalPhoneNumberWidget

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,10 @@ Included are:
 * ``PhoneNumberField``, a serializer field
 * ``PhoneNumberPrefixWidget``, a form widget for selecting a region code and
   entering a national number. Requires the `Babel`_ package be installed.
-* ``PhoneNumberInternationalFallbackWidget``, a form widget that uses national numbers unless an
-  international number is entered.  A ``PHONENUMBER_DEFAULT_REGION`` setting needs to be added
-  to your Django settings in order to know which national number format to recognize.
+* ``RegionalPhoneNumberWidget``, a form widget that uses national numbers
+  unless an international number is entered.  A ``PHONENUMBER_DEFAULT_REGION``
+  setting needs to be added to your Django settings in order to know which
+  national number format to recognize.
 
 .. _`Babel`: https://pypi.org/project/Babel/
 

--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -8,12 +8,12 @@ from django.utils.translation import gettext_lazy as _
 
 from phonenumber_field.phonenumber import to_python, validate_region
 from phonenumber_field.validators import validate_international_phonenumber
-from phonenumber_field.widgets import PhoneNumberInternationalFallbackWidget
+from phonenumber_field.widgets import RegionalPhoneNumberWidget
 
 
 class PhoneNumberField(CharField):
     default_validators = [validate_international_phonenumber]
-    widget = PhoneNumberInternationalFallbackWidget
+    widget = RegionalPhoneNumberWidget
 
     def __init__(self, *args, region=None, widget=None, **kwargs):
         validate_region(region)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -9,6 +9,7 @@ from phonenumber_field.phonenumber import PhoneNumber
 from phonenumber_field.widgets import (
     PhoneNumberInternationalFallbackWidget,
     PhoneNumberPrefixWidget,
+    RegionalPhoneNumberWidget,
 )
 
 
@@ -239,7 +240,79 @@ class PhoneNumberPrefixWidgetTest(SimpleTestCase):
         )
 
 
+class RegionalPhoneNumberWidgetTest(SimpleTestCase):
+    @override_settings(PHONENUMBER_DEFAULT_FORMAT="INTERNATIONAL")
+    def test_fallback_widget_switches_between_national_and_international(self):
+        region = "GB"
+        number_string = "01606 751 78"
+        number = PhoneNumber.from_string(number_string, region=region)
+        gb_widget = RegionalPhoneNumberWidget()
+        gb_widget.region = "GB"
+        de_widget = RegionalPhoneNumberWidget()
+        de_widget.region = "DE"
+        self.assertHTMLEqual(
+            gb_widget.render("number", number),
+            '<input name="number" type="tel" value="01606 75178" />',
+        )
+        self.assertHTMLEqual(
+            de_widget.render("number", number),
+            '<input name="number" type="tel" value="+44 1606 75178" />',
+        )
+
+        # If there's been a validation error, the value should be included verbatim
+        self.assertHTMLEqual(
+            gb_widget.render("number", "error"),
+            '<input name="number" type="tel" value="error" />',
+        )
+
+    def test_fallback_defaults_to_phonenumber_default_format(self):
+        region = "GB"
+        number_string = "01606 751 78"
+        number = PhoneNumber.from_string(number_string, region=region)
+        widget = RegionalPhoneNumberWidget(region="FR")
+        for fmt, expected in [
+            ("INTERNATIONAL", "+44 1606 75178"),
+            ("E164", "+44160675178"),
+            ("RFC3966", "tel:+44-1606-75178"),
+        ]:
+            with self.subTest(fmt):
+                with override_settings(PHONENUMBER_DEFAULT_FORMAT=fmt):
+                    self.assertHTMLEqual(
+                        widget.render("number", number),
+                        f'<input name="number" type="tel" value="{expected}" />',
+                    )
+
+    def test_no_region(self):
+        number_string = "+33612345678"
+        number = PhoneNumber.from_string(number_string)
+        widget = RegionalPhoneNumberWidget()
+        for fmt, expected in [
+            ("INTERNATIONAL", "+33 6 12 34 56 78"),
+            ("E164", "+33612345678"),
+            ("RFC3966", "tel:+33-6-12-34-56-78"),
+        ]:
+            with self.subTest(fmt):
+                with override_settings(PHONENUMBER_DEFAULT_FORMAT=fmt):
+                    self.assertHTMLEqual(
+                        widget.render("number", number),
+                        f'<input name="number" type="tel" value="{expected}" />',
+                    )
+
+
 class PhoneNumberInternationalFallbackWidgetTest(SimpleTestCase):
+    def test_raises_deprecation_warning(self):
+        msg = (
+            "PhoneNumberInternationalFallbackWidget will be removed in the next major "
+            "version. Use phonenumber_field.widgets.RegionalPhoneNumberWidget "
+            "instead."
+        )
+        with self.assertWarnsMessage(DeprecationWarning, msg):
+
+            class _(forms.Form):
+                number = formfields.PhoneNumberField(
+                    widget=PhoneNumberInternationalFallbackWidget
+                )
+
     def test_fallback_widget_switches_between_national_and_international(self):
         region = "GB"
         number_string = "01606 751 78"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -552,7 +552,7 @@ class RegionPhoneNumberModelFieldTest(TestCase):
             "<input "
             'type="tel" '
             'name="phone" '
-            'value="+32 468 54 78 25" '
+            'value="+32468547825" '
             'maxlength="128" '
             'id="id_phone">'
             "</p>",
@@ -568,7 +568,7 @@ class RegionPhoneNumberModelFieldTest(TestCase):
             "<input "
             'type="tel" '
             'name="phone" '
-            'value="+32 468 54 78 25" '
+            'value="+32468547825" '
             'maxlength="128" '
             'id="id_phone">'
             "</p>",


### PR DESCRIPTION
Instead of hardcoding the INTERNATIONAL format, follow the
PHONENUMBER_DEFAULT_FORMAT preference (defaulting to E164).

The PhoneNumberInternationalWidget is now deprecated and will be removed
in the next major version. Use PhoneNumberWithFallbackWidget with
setting PHONENUMBER_DEFAULT_FORMAT="INTERNATIONAL" instead.