### PR TITLE
Add documentation and host it at readthedocs.org

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         tox-environment:
           - black
+          - doctest
           - flake8
           - isort
     env:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+
+sphinx:
+  fail_on_warning: yes

--- a/README.rst
+++ b/README.rst
@@ -12,109 +12,12 @@ phone numbers. ``python-phonenumbers`` is a port of Google's `libphonenumber`_ l
 powers Android's phone number handling.
 
 .. _`python-phonenumbers`: https://github.com/daviddrysdale/python-phonenumbers
-.. _`libphonenumber`: https://code.google.com/p/libphonenumber/
+.. _`libphonenumber`: https://github.com/google/libphonenumber
 
-Included are:
+Documentation
+=============
 
-* ``PhoneNumber``, a pythonic wrapper around ``python-phonenumbers``' ``PhoneNumber`` class
-* ``PhoneNumberField``, a model field
-* ``PhoneNumberField``, a form field
-* ``PhoneNumberField``, a serializer field
-* ``PhoneNumberPrefixWidget``, a form widget for selecting a region code and
-  entering a national number. Requires the `Babel`_ package be installed.
-* ``RegionalPhoneNumberWidget``, a form widget that uses national numbers
-  unless an international number is entered.  A ``PHONENUMBER_DEFAULT_REGION``
-  setting needs to be added to your Django settings in order to know which
-  national number format to recognize.
-
-.. _`Babel`: https://pypi.org/project/Babel/
-
-Installation
-============
-
-::
-
-    pip install django-phonenumber-field[phonenumbers]
-
-As an alternative to the ``phonenumbers`` package, it is possible to install
-the ``phonenumberslite`` package which has `a lower memory footprint
-<https://github.com/daviddrysdale/python-phonenumbers#memory-usage>`_.
-
-::
-
-    pip install django-phonenumber-field[phonenumberslite]
-
-Basic usage
-===========
-
-First, add ``phonenumber_field`` to the list of the installed apps in
-your ``settings.py`` file:
-
-.. code-block:: python
-
-    INSTALLED_APPS = [
-        ...
-        'phonenumber_field',
-        ...
-    ]
-
-Then, you can use it like any regular model field:
-
-.. code-block:: python
-
-    from phonenumber_field.modelfields import PhoneNumberField
-
-    class MyModel(models.Model):
-        name = models.CharField(max_length=255)
-        phone_number = PhoneNumberField()
-        fax_number = PhoneNumberField(blank=True)
-
-Internally, PhoneNumberField is based upon ``CharField`` and by default
-represents the number as a string of an international phonenumber in the database (e.g
-``'+41524204242'``).
-
-The object returned is a PhoneNumber instance, not a string. If strings are used to initialize it,
-e.g. via ``MyModel(phone_number='+41524204242')`` or form handling, it has to be a phone number
-with country code.
-
-Settings
-========
-
-``PHONENUMBER_DB_FORMAT``
--------------------------
-
-Store phone numbers strings in the specified format.
-
-Default: ``"E164"``.
-
-Choices:
-
-- ``"E164"``,
-- ``"INTERNATIONAL"``,
-- ``"NATIONAL"`` (requires ``PHONENUMBER_DEFAULT_REGION``),
-- ``"RFC3966"`` (requires ``PHONENUMBER_DEFAULT_REGION``).
-
-``PHONENUMBER_DEFAULT_REGION``
-------------------------------
-
-`ISO-3166-1 <https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes>`_
-two-letter country code indicating how to interpret regional phone numbers.
-
-Default: ``None``.
-
-``PHONENUMBER_DEFAULT_FORMAT``
-------------------------------
-
-String formatting of phone numbers.
-
-Default: ``"E164"``.
-
-Choices:
-
-- ``"E164"``,
-- ``"INTERNATIONAL"``,
-- ``"NATIONAL"``,
-- ``"RFC3966"``.
+https://django-phonenumber-field.readthedocs.io/
 
 Running tests
 =============

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,50 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+import os
+import pathlib
+import sys
+
+current_dir = pathlib.Path(__file__).parent
+# Find current settings module for doctests.
+sys.path.insert(0, str(current_dir))
+sys.path.insert(0, str(current_dir / "ext"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "django-phonenumber-field"
+copyright = "2022, django-phonenumber-field"
+author = "Stefan Foulis"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "phonenumber_field_docs",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = []
+
+# -- Options for extensions --------------------------------------------------
+
+intersphinx_mapping = {
+    "django": (
+        "https://docs.djangoproject.com/en/dev/",
+        "https://docs.djangoproject.com/en/dev/_objects/",
+    ),
+    "python": ("https://docs.python.org/3/", None),
+}

--- a/docs/ext/phonenumber_field_docs.py
+++ b/docs/ext/phonenumber_field_docs.py
@@ -1,0 +1,4 @@
+def setup(app):
+    app.add_crossref_type(
+        directivename="setting", rolename="setting", indextemplate="pair: %s; setting"
+    )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,47 @@
+🕿 django-phonenumber-field 🕿
+=============================
+
+A `Django <https://www.djangoproject.com/>`_ library which interfaces with
+`python-phonenumbers <https://github.com/daviddrysdale/python-phonenumbers>`_
+to validate, pretty print and convert phone numbers. The python-phonenumbers
+library is a port of Google’s `libphonenumber
+<https://github.com/google/libphonenumber>`_ library, which powers Android’s
+phone number handling.
+
+Installation
+============
+
+Choosing a phonenumbers provider
+--------------------------------
+
+The `python-phonenumbers <https://github.com/daviddrysdale/python-phonenumbers>`_ library comes in `two flavors
+<https://github.com/daviddrysdale/python-phonenumbers#memory-usage>`_:
+
+.. code-block::
+
+    # Installs phonenumbers minimal metadata
+    pip install "django-phonenumber-field[phonenumberslite]"
+
+.. code-block::
+
+    # Installs phonenumbers extended features (e.g. geocoding)
+    pip install "django-phonenumber-field[phonenumbers]"
+
+Setup
+-----
+
+Add ``phonenumber_field`` to the list of the installed apps in
+your ``settings.py`` file :external+django:setting:`INSTALLED_APPS`:
+
+.. code-block:: python
+
+    INSTALLED_APPS = [
+        # Other apps…
+        "phonenumber_field",
+    ]
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   reference

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,0 +1,398 @@
+.. testsetup:: *
+
+   import django
+   from bs4 import BeautifulSoup
+
+   django.setup()
+
+   def print_html(html):
+       print(BeautifulSoup(html).prettify())
+
+
+The PhoneNumber wrapper
+=======================
+
+.. autoclass:: phonenumber_field.phonenumber.PhoneNumber()
+
+   .. automethod:: phonenumber_field.phonenumber.PhoneNumber.from_string
+
+   .. automethod:: phonenumber_field.phonenumber.PhoneNumber.is_valid
+
+   .. autoproperty:: phonenumber_field.phonenumber.PhoneNumber.as_international
+
+   .. autoproperty:: phonenumber_field.phonenumber.PhoneNumber.as_national
+
+   .. autoproperty:: phonenumber_field.phonenumber.PhoneNumber.as_e164
+
+   .. autoproperty:: phonenumber_field.phonenumber.PhoneNumber.as_rfc3966
+
+Usage
+-----
+
+.. doctest:: wrapper
+
+   >>> from phonenumber_field.phonenumber import PhoneNumber
+
+   >>> number = PhoneNumber.from_string("+16044011234")
+   >>> print(number.as_national)
+   (604) 401-1234
+   >>> print(number.as_e164)
+   +16044011234
+   >>> print(number.as_international)
+   +1 604-401-1234
+   >>> print(number.as_rfc3966)
+   tel:+1-604-401-1234
+
+   # Using national numbers with the region keyword argument.
+   >>> canadian_number = "(604) 401 1234"
+   >>> number = PhoneNumber.from_string(canadian_number, region="CA")
+   >>> print(number.as_e164)
+   +16044011234
+
+Model field
+===========
+
+The :class:`~phonenumber_field.modelfields.PhoneNumberField` :ref:`model field
+<topics/db/models:fields>` allows storing
+:class:`~phonenumber_field.phonenumber.PhoneNumber`\ s in the database, based
+on a :class:`~django.db.models.CharField`.
+
+The phone number format used by the database is controlled with
+:setting:`PHONENUMBER_DB_FORMAT`. When no region is specified, a phone number
+in the ``"NATIONAL"`` format will be assumed to be from the
+:setting:`PHONENUMBER_DEFAULT_REGION`.
+
+- The default :ref:`form field <ref/forms/fields:form fields>` for this field is
+  the :class:`~phonenumber_field.formfields.PhoneNumberField`.
+- The default :ref:`form widget <ref/forms/widgets:widgets>` for this field is
+  the :class:`~phonenumber_field.widgets.RegionalPhoneNumberWidget`.
+
+.. autoclass:: phonenumber_field.modelfields.PhoneNumberField
+
+   .. automethod:: __init__
+
+Usage
+-----
+
+.. code-block:: python
+
+   from django.db import models
+   from phonenumber_field.modelfields import PhoneNumberField
+
+
+   class Customer(models.Model):
+       name = models.TextField()
+       # An optional phone number.
+       phone_number = PhoneNumberField(blank=True)
+
+Form field
+==========
+
+The :class:`~phonenumber_field.formfields.PhoneNumberField` :ref:`form field
+<ref/forms/fields:form fields>` to validate
+:class:`~phonenumber_field.phonenumber.PhoneNumber`, based on a
+:class:`~django.forms.CharField`.
+
+- Default widget: :class:`~phonenumber_field.widgets.RegionalPhoneNumberWidget`
+- Empty value: ``""``
+- Normalizes to: A :class:`~phonenumber_field.phonenumber.PhoneNumber` or an
+  empty :class:`str` (``""``)
+- Uses :func:`~phonenumber_field.validators.validate_international_phonenumber`
+
+.. autoclass:: phonenumber_field.formfields.PhoneNumberField
+
+   .. automethod:: __init__
+
+Usage
+-----
+
+.. doctest:: formfield
+
+   >>> from django import forms
+   >>> from phonenumber_field.formfields import PhoneNumberField
+
+   >>> class PhoneForm(forms.Form):
+   ...     number = PhoneNumberField(region="CA")
+   ...
+
+   # Manipulating data
+   >>> form = PhoneForm({"number": "+1 604 401 1234"})
+   >>> form.is_valid()
+   True
+   >>> form.cleaned_data
+   {'number': PhoneNumber(country_code=1, national_number=6044011234, extension=None, italian_leading_zero=None, number_of_leading_zeros=None, country_code_source=1, preferred_domestic_carrier_code=None)}
+   >>> print_html(form.as_div())
+   <div>
+    <label for="id_number">
+     Number:
+    </label>
+    <input id="id_number" name="number" required="" type="tel" value="(604) 401-1234"/>
+   </div>
+
+   # Handling errors
+   >>> form = PhoneForm({"number": "invalid"})
+   >>> form.is_valid()
+   False
+   >>> print_html(form.as_div())
+   <div>
+    <label for="id_number">
+     Number:
+    </label>
+    <ul class="errorlist">
+     <li>
+      Enter a valid phone number (e.g. (506) 234-5678) or a number with an international call prefix.
+     </li>
+    </ul>
+    <input id="id_number" name="number" required="" type="tel" value="invalid"/>
+   </div>
+
+.. note:: Because the PhoneNumberField specifies a region, the example number
+   is a national number from that region. When no region is specified, an
+   international example phone number in the E.164 format is suggested.
+
+
+Widgets
+-------
+
+RegionalPhoneNumberWidget
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Default widget** for :class:`~phonenumber_field.formfields.PhoneNumberField`.
+
+- input_type: ``tel``
+- Renders as ``<input type="tel" … >``
+
+.. important:: The region should be specified (either per field using the
+   ``region`` keyword argument, or with the
+   :setting:`PHONENUMBER_DEFAULT_REGION` setting) in order to know which
+   national number format to recognize.
+
+
+.. autoclass:: phonenumber_field.widgets.RegionalPhoneNumberWidget
+
+   .. automethod:: __init__
+
+Usage
+.....
+
+.. doctest:: fallbackwidget
+
+   >>> from django import forms
+   >>> from phonenumber_field.formfields import PhoneNumberField
+
+   >>> class CanadianPhoneForm(forms.Form):
+   ...     # RegionalPhoneNumberWidget is the default widget.
+   ...     number = PhoneNumberField(region="CA")
+   ...
+
+   # Using the national format for the field’s region.
+   >>> form = CanadianPhoneForm({"number": "+16044011234"})
+   >>> print_html(form.as_div())
+   <div>
+    <label for="id_number">
+     Number:
+    </label>
+    <input id="id_number" name="number" required="" type="tel" value="(604) 401-1234"/>
+   </div>
+
+   # Using E164 for an international number.
+   >>> french_number = "+33612345678"
+   >>> form = CanadianPhoneForm({"number": french_number})
+   >>> print_html(form.as_div())
+   <div>
+    <label for="id_number">
+     Number:
+    </label>
+    <input id="id_number" name="number" required="" type="tel" value="+33612345678"/>
+   </div>
+
+PhoneNumberPrefixWidget
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. important:: Requires the `Babel <https://pypi.org/project/Babel/>`_ package
+   be installed.
+
+.. autoclass:: phonenumber_field.widgets.PhoneNumberPrefixWidget
+
+   .. automethod:: __init__
+
+Usage
+.....
+
+.. doctest:: prefixwidget
+
+   >>> from django import forms
+   >>> from phonenumber_field.formfields import PhoneNumberField
+   >>> from phonenumber_field.widgets import PhoneNumberPrefixWidget
+
+   # Limiting country choices.
+   >>> class CanadianPhoneForm(forms.Form):
+   ...     # RegionalPhoneNumberWidget is the default widget.
+   ...     number = PhoneNumberField(
+   ...         region="CA",
+   ...         widget=PhoneNumberPrefixWidget(
+   ...             country_choices=[
+   ...                  ("CA", "Canada"),
+   ...                  ("FR", "France"),
+   ...             ],
+   ...         ),
+   ...     )
+   ...
+
+   >>> form = CanadianPhoneForm({"number_0": "CA", "number_1": "6044011234"})
+   >>> print_html(form.as_div())
+   <div>
+    <fieldset>
+     <legend>
+      Number:
+     </legend>
+     <select id="id_number_0" name="number_0" required="">
+      <option selected="" value="CA">
+       Canada
+      </option>
+      <option value="FR">
+       France
+      </option>
+     </select>
+     <input id="id_number_1" name="number_1" required="" type="text" value="6044011234"/>
+    </fieldset>
+   </div>
+
+   # Pre-selecting a country.
+   >>> class FrenchPhoneForm(forms.Form):
+   ...     # RegionalPhoneNumberWidget is the default widget.
+   ...     number = PhoneNumberField(
+   ...         region="FR",
+   ...         widget=PhoneNumberPrefixWidget(
+   ...             initial="FR",
+   ...             country_choices=[
+   ...                  ("CA", "Canada"),
+   ...                  ("FR", "France"),
+   ...             ],
+   ...         ),
+   ...     )
+   ...
+
+   >>> form = FrenchPhoneForm()
+   >>> print_html(form.as_div())
+   <div>
+    <fieldset>
+     <legend>
+      Number:
+     </legend>
+     <select id="id_number_0" name="number_0" required="">
+      <option value="CA">
+       Canada
+      </option>
+      <option selected="" value="FR">
+       France
+      </option>
+     </select>
+     <input id="id_number_1" name="number_1" required="" type="text"/>
+    </fieldset>
+   </div>
+
+Serializer field
+================
+
+The :class:`~phonenumber_field.serializersfields.PhoneNumberField` `serializer
+field <https://www.django-rest-framework.org/api-guide/fields/>`_, based on the
+`CharField
+<https://www.django-rest-framework.org/api-guide/fields/#charfield>`_.
+
+The serialization format is controlled by the
+:setting:`PHONENUMBER_DEFAULT_FORMAT`.
+
+.. autoclass:: phonenumber_field.serializerfields.PhoneNumberField
+
+   .. automethod:: __init__
+
+Usage
+-----
+
+.. doctest:: serializerfield
+
+    >>> from django.conf import settings
+    >>> from rest_framework import renderers, serializers
+    >>> from phonenumber_field.serializerfields import PhoneNumberField
+
+    >>> class PhoneNumberSerializer(serializers.Serializer):
+    ...     number = PhoneNumberField(region="CA")
+    ...
+
+    >>> serializer = PhoneNumberSerializer(data={"number": "604 401 1234"})
+    >>> serializer.is_valid()
+    True
+    >>> serializer.validated_data
+    OrderedDict([('number', PhoneNumber(country_code=1, national_number=6044011234, extension=None, italian_leading_zero=None, number_of_leading_zeros=None, country_code_source=20, preferred_domestic_carrier_code=None))])
+
+    # Using the PHONENUMBER_DEFAULT_FORMAT.
+    >>> renderers.JSONRenderer().render(serializer.data)
+    b'{"number":"+16044011234"}'
+
+
+Validator
+=========
+
+Validates:
+
+- a :class:`~phonenumber_field.phonenumber.PhoneNumber` instance, or
+- an :class:`str` in an international format (with a prefix), or
+- an :class:`str` that’s a local phone number according to
+  :setting:`PHONENUMBER_DEFAULT_REGION`.
+
+.. note:: Not all well-formed phone numbers are valid. The rules to construct
+   phone numbers vary per region of the world.
+
+   `Falsehoods Programmers Believe About Phone Numbers
+   <https://github.com/google/libphonenumber/blob/master/FALSEHOODS.md>`_ is a
+   good read.
+
+.. autofunction:: phonenumber_field.validators.validate_international_phonenumber
+
+**code**: ``"invalid_phone_number"``
+
+Settings
+========
+
+.. setting:: PHONENUMBER_DB_FORMAT
+
+``PHONENUMBER_DB_FORMAT``
+-------------------------
+
+Store phone numbers strings in the specified format.
+
+Default: ``"E164"``.
+
+Choices:
+
+- ``"E164"``,
+- ``"INTERNATIONAL"``,
+- ``"RFC3966"``,
+- ``"NATIONAL"`` (discouraged, requires :setting:`PHONENUMBER_DEFAULT_REGION`).
+
+.. setting:: PHONENUMBER_DEFAULT_REGION
+
+``PHONENUMBER_DEFAULT_REGION``
+------------------------------
+
+`ISO-3166-1 <https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes>`_
+two-letter country code indicating how to interpret regional phone numbers.
+
+Default: ``None``.
+
+.. setting:: PHONENUMBER_DEFAULT_FORMAT
+
+``PHONENUMBER_DEFAULT_FORMAT``
+------------------------------
+
+String formatting of phone numbers.
+
+Default: ``"E164"``.
+
+Choices:
+
+- ``"E164"``,
+- ``"INTERNATIONAL"``,
+- ``"RFC3966"``,
+- ``"NATIONAL"`` (discouraged, fails to represent international phone numbers).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+django
+djangorestframework
+phonenumberslite

--- a/docs/settings.py
+++ b/docs/settings.py
@@ -1,0 +1,3 @@
+DATABASES = {}
+SECRET_KEY = "secretkey"
+INSTALLED_APPS = ["phonenumber_field"]

--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -16,6 +16,12 @@ class PhoneNumberField(CharField):
     widget = RegionalPhoneNumberWidget
 
     def __init__(self, *args, region=None, widget=None, **kwargs):
+        """
+        :keyword str region: 2-letter country code as defined in ISO 3166-1.
+            When not supplied, defaults to :setting:`PHONENUMBER_DEFAULT_REGION`
+        :keyword django.forms.Widget widget: defaults to
+            :class:`~phonenumber_field.widgets.RegionalPhoneNumberWidget`
+        """
         validate_region(region)
         self.region = region or getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
 

--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -53,6 +53,11 @@ class PhoneNumberField(models.CharField):
     description = _("Phone number")
 
     def __init__(self, *args, region=None, **kwargs):
+        """
+        :keyword str region: 2-letter country code as defined in ISO 3166-1.
+            When not supplied, defaults to :setting:`PHONENUMBER_DEFAULT_REGION`
+        :keyword int max_length: The maximum length of the underlying char field.
+        """
         kwargs.setdefault("max_length", 128)
         super().__init__(*args, **kwargs)
         self._region = region

--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -22,6 +22,11 @@ class PhoneNumber(phonenumbers.PhoneNumber):
 
     @classmethod
     def from_string(cls, phone_number, region=None):
+        """
+        :arg str phone_number: parse this :class:`str` as a phone number.
+        :keyword str region: 2-letter country code as defined in ISO 3166-1.
+            When not supplied, defaults to :setting:`PHONENUMBER_DEFAULT_REGION`
+        """
         phone_number_obj = cls()
         if region is None:
             region = getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
@@ -48,7 +53,10 @@ class PhoneNumber(phonenumbers.PhoneNumber):
 
     def is_valid(self):
         """
-        checks whether the number supplied is actually valid
+        Whether the number supplied is actually valid.
+
+        :return: ``True`` when the phone number is valid.
+        :rtype: bool
         """
         return phonenumbers.is_valid_number(self)
 

--- a/phonenumber_field/serializerfields.py
+++ b/phonenumber_field/serializerfields.py
@@ -10,6 +10,10 @@ class PhoneNumberField(serializers.CharField):
     default_error_messages = {"invalid": _("Enter a valid phone number.")}
 
     def __init__(self, *args, region=None, **kwargs):
+        """
+        :keyword str region: 2-letter country code as defined in ISO 3166-1.
+            When not supplied, defaults to :setting:`PHONENUMBER_DEFAULT_REGION`
+        """
         super().__init__(*args, **kwargs)
         validate_region(region)
         self.region = region or getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)

--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -66,9 +66,10 @@ class PhonePrefixSelect(Select):
 
 class PhoneNumberPrefixWidget(MultiWidget):
     """
-    A Widget that splits phone number input into:
-    - a country select box for phone prefix
-    - an input for local phone number
+    A Widget that splits a phone number into fields:
+
+    - a :class:`~django.forms.Select` for the country (phone prefix)
+    - a :class:`~django.forms.TextInput` for local phone number
     """
 
     def __init__(
@@ -80,11 +81,17 @@ class PhoneNumberPrefixWidget(MultiWidget):
         number_attrs=None,
     ):
         """
-        :param country_choices: Limit the country choices.
+        :keyword dict attrs: See :attr:`~django.forms.Widget.attrs`
+        :keyword dict initial: See :attr:`~django.forms.Field.initial`
+        :keyword dict country_attrs: The :attr:`~django.forms.Widget.attrs` for
+            the country :class:`~django.forms.Select`.
+        :keyword country_choices: Limit the country choices.
         :type country_choices: list of 2-tuple, optional
             The first element is the value, which must match a country code
             recognized by the phonenumbers project.
             The second element is the label.
+        :keyword dict number_attrs: The :attr:`~django.forms.Widget.attrs` for
+            the local phone number :class:`~django.forms.TextInput`.
         """
         widgets = (
             PhonePrefixSelect(initial, attrs=country_attrs, choices=country_choices),
@@ -117,13 +124,19 @@ class PhoneNumberPrefixWidget(MultiWidget):
 
 class RegionalPhoneNumberWidget(TextInput):
     """
-    A Widget that allows a phone number in a national format, but if given
-    an international number will fall back to international format
+    A :class:`~django.forms.Widget` that prefers displaying numbers in the
+    national format, and falls back to :setting:`PHONENUMBER_DEFAULT_FORMAT`
+    for international numbers.
     """
 
     input_type = "tel"
 
     def __init__(self, region=None, attrs=None):
+        """
+        :keyword str region: 2-letter country code as defined in ISO 3166-1.
+            When not supplied, defaults to :setting:`PHONENUMBER_DEFAULT_REGION`
+        :keyword dict attrs: See :attr:`django.forms.Widget.attrs`
+        """
         if region is None:
             region = getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
         self.region = region

--- a/tox.ini
+++ b/tox.ini
@@ -50,3 +50,15 @@ commands =
 deps =
     isort>=5.0.2
 skip_install = true
+
+[testenv:doctest]
+deps =
+    beautifulsoup4
+    django
+    djangorestframework
+    Sphinx
+    sphinx-rtd-theme
+changedir = docs/
+allowlist_externals=make
+commands =
+    make doctest


### PR DESCRIPTION
The documentation is built with Sphinx, and hosted on readthedocs.org.
The README was stripped to its bare minimum, and now points to the documentation.
Code excerpt are verified with doctest.

Fixes #52 
Fixes #152 
Refs #224 