### PR TITLE
Use attributes and methods from phonenumbers

### DIFF
--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -157,11 +157,8 @@ def to_python(value, region=None):
 
 
 def validate_region(region):
-    if (
-        region is not None
-        and region not in phonenumbers.phonenumberutil.SUPPORTED_REGIONS
-    ):
+    if region is not None and region not in phonenumbers.SUPPORTED_REGIONS:
         raise ValueError(
             "“%s” is not a valid region code. Choices are %r"
-            % (region, phonenumbers.phonenumberutil.SUPPORTED_REGIONS)
+            % (region, phonenumbers.SUPPORTED_REGIONS)
         )

--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.forms import Select, TextInput
 from django.forms.widgets import MultiWidget
 from django.utils import translation
-from phonenumbers.phonenumberutil import (
+from phonenumbers import (
     COUNTRY_CODE_TO_REGION_CODE,
     national_significant_number,
     region_code_for_number,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,7 +4,6 @@ from django.core import checks
 from django.db.models import Model
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils.encoding import force_str
-from phonenumbers import phonenumberutil
 
 from phonenumber_field import formfields, modelfields
 from phonenumber_field.phonenumber import PhoneNumber, to_python
@@ -129,9 +128,7 @@ class PhoneNumberFieldTestCase(TestCase):
         self.assertIsNone(model.phone_number)
         model.phone_number = self.test_number_1
         self.assertIsInstance(model.phone_number, PhoneNumber)
-        model.phone_number = phonenumberutil.parse(
-            self.test_number_1, keep_raw_input=True
-        )
+        model.phone_number = phonenumbers.parse(self.test_number_1, keep_raw_input=True)
         self.assertIsInstance(model.phone_number, PhoneNumber)
 
     def test_can_assign_string_phone_number(self):
@@ -149,10 +146,10 @@ class PhoneNumberFieldTestCase(TestCase):
 
     def test_can_assign_phonenumber(self):
         """
-        Tests assignment phonenumberutil.PhoneNumber to field
+        Tests assignment phonenumbers.PhoneNumber to field
         """
         opt_phone = models.OptionalPhoneNumber()
-        opt_phone.phone_number = phonenumberutil.parse(
+        opt_phone.phone_number = phonenumbers.parse(
             self.test_number_1, keep_raw_input=True
         )
         self.assertIsInstance(opt_phone.phone_number, PhoneNumber)


### PR DESCRIPTION
Instead of loading from the submodules, keep to the phonenumbers module.
That avoids prying into its implementation.