### PR TITLE
Add common virtualenv locations to flake8 exclude and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ share/
 .coverage*
 # Written by setuptools_scm.
 phonenumber_field/version.py
+# python virtualenv
+.venv/
+venv/
+# python virtualenv or environment file (potential secrets)
+.env

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,10 @@ phonenumberslite =
 [flake8]
 max-line-length = 88
 show-source = True
+extend-exclude =
+    .env/
+    .venv/
+    venv/
 
 [isort]
 profile = black


### PR DESCRIPTION
A minor quality of life improvement for (potential) contributors, this stops flake8 generating a barrage of errors when run, if you have a virtualenv in one of the common in-tree locations (.venv/, venv/ .env/).

Adds these paths to both flake8 extend-ignore in setup.cfg and .gitignore

Fixes #546