### PR TITLE
Update python and Django matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,17 @@ jobs:
           - 3.8
           - 3.9
           - '3.10'
+          - '3.11'
         tox-environment:
           - dj32
           - dj40
           - dj41
-          - djmain
+          - dj42
         include:
           - python-version: 3.7
             tox-environment: dj32
+          - python-version: '3.10'
+            tox-environment: djmain
 
     env:
       COVERALLS_FLAG_NAME: Python ${{ matrix.python-version }} / ${{ matrix.tox-environment }}

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     dj32
     dj40
     dj41
+    dj42
     djmain
 isolated_build = true
 minversion = 1.9
@@ -17,6 +18,7 @@ deps =
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2b1,<4.3
     djmain: https://github.com/django/django/archive/main.tar.gz
     djangorestframework
 extras = phonenumberslite


### PR DESCRIPTION
Django main only supports Python 3.10+. The 4.2 release is in alpha
stages.