### PR TITLE
Strip trailing line from beautifulsoup prettify output

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -6,7 +6,7 @@
    django.setup()
 
    def print_html(html):
-       print(BeautifulSoup(html).prettify())
+       print(BeautifulSoup(html).prettify().strip())
 
 
 The PhoneNumber wrapper


### PR DESCRIPTION
From beautifulsoup version 4.12.1 (20230405):
* Tag.prettify() will now consistently end prettified markup with
  a newline.

https://git.launchpad.net/beautifulsoup/tree/CHANGELOG