### PR TITLE
Fix setuptools warning when making a release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,9 @@ classifiers =
 
 [options]
 zip_safe = false
-include_package_data = true
 python_requires = >=3.7
 install_requires =
     Django >= 3.2
-packages =
-    phonenumber_field
 
 [options.extras_require]
 phonenumbers =


### PR DESCRIPTION
/tmp/build-env-5joetq8r/lib/python3.10/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'phonenumber_field.locale.zh_Hans.LC_MESSAGES' is absent from the `packages` configuration. !!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'phonenumber_field.locale.zh_Hans.LC_MESSAGES' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'phonenumber_field.locale.zh_Hans.LC_MESSAGES' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'phonenumber_field.locale.zh_Hans.LC_MESSAGES' to be distributed and are
        already explicitly excluding 'phonenumber_field.locale.zh_Hans.LC_MESSAGES' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html

        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)