### PR TITLE
Switch to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,53 @@
+[project]
+name = "django-phonenumber-field"
+requires-python = ">=3.7"
+description = "An international phone number field for django models."
+readme = "README.rst"
+authors = [
+    { name="Stefan Foulis", email="stefan@foulis.ch" },
+    { name="François Freitag", email="mail@franek.fr" },
+]
+maintainers = [
+    { name="François Freitag", email="mail@franek.fr" },
+    { name="Stefan Foulis", email="stefan@foulis.ch" },
+]
+license = { text="MIT" }
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: Django",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Internet :: WWW/HTTP",
+]
+dynamic = ["version"]
+dependencies = ["Django>=3.2"]
+
+[project.optional-dependencies]
+phonenumbers = ["phonenumbers >= 7.0.2"]
+phonenumberslite = ["phonenumberslite >= 7.0.2"]
+
+[project.urls]
+Homepage = "https://github.com/stefanfoulis/django-phonenumber-field"
+Documentation = "https://django-phonenumber-field.readthedocs.io/"
+Source = "https://github.com/stefanfoulis/django-phonenumber-field"
+Tracker = "https://github.com/stefanfoulis/django-phonenumber-field/issues/"
+Changelog = "https://github.com/stefanfoulis/django-phonenumber-field/releases/"
+
+[tool.isort]
+profile = "black"
+
 [build-system]
 requires = [
     "setuptools>=42",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,45 +1,3 @@
-[metadata]
-name = django-phonenumber-field
-description = An international phone number field for django models.
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-url = https://github.com/stefanfoulis/django-phonenumber-field
-license = MIT
-author = Stefan Foulis
-author_email = stefan@foulis.ch
-maintainer = Stefan Foulis
-maintainer_email = stefan@foulis.ch
-platforms = OS Independent
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Framework :: Django
-    Framework :: Django :: 3.2
-    Framework :: Django :: 4.1
-    Framework :: Django :: 4.2
-    Intended Audience :: Developers
-    License :: OSI Approved :: MIT License
-    Operating System :: OS Independent
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: Implementation :: CPython
-    Topic :: Internet :: WWW/HTTP
-
-[options]
-python_requires = >=3.7
-install_requires =
-    Django >= 3.2
-
-[options.extras_require]
-phonenumbers =
-    phonenumbers >= 7.0.2
-phonenumberslite =
-    phonenumberslite >= 7.0.2
-
 [flake8]
 max-line-length = 88
 show-source = True
@@ -47,6 +5,3 @@ extend-exclude =
     .env/
     .venv/
     venv/
-
-[isort]
-profile = black


### PR DESCRIPTION
Starting with [PEP 621](https://peps.python.org/pep-0621/), the Python community selected pyproject.toml as a standard way of specifying project metadata. Setuptools has adopted this standard and will use the information contained in this file as an input in the build process.