### PR TITLE
Add sphinx-rtd-theme to documentation requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 django
 djangorestframework
 phonenumberslite
+sphinx-rtd-theme


### PR DESCRIPTION
Fixes build error:
```
$ python -m sphinx -T -E -W --keep-going -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
Running Sphinx v7.2.6
making output directory... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-phonenumber-field/envs/576/lib/python3.11/site-packages/sphinx/cmd/build.py", line 293, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-phonenumber-field/envs/576/lib/python3.11/site-packages/sphinx/application.py", line 272, in __init__
    self._init_builder()
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-phonenumber-field/envs/576/lib/python3.11/site-packages/sphinx/application.py", line 342, in _init_builder
    self.builder.init()
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-phonenumber-field/envs/576/lib/python3.11/site-packages/sphinx/builders/html/__init__.py", line 219, in init
    self.init_templates()
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-phonenumber-field/envs/576/lib/python3.11/site-packages/sphinx/builders/html/__init__.py", line 270, in init_templates
    self.theme = theme_factory.create(themename)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-phonenumber-field/envs/576/lib/python3.11/site-packages/sphinx/theming.py", line 230, in create
    raise ThemeError(__('no theme named %r found (missing theme.conf?)') % name)
sphinx.errors.ThemeError: no theme named 'sphinx_rtd_theme' found (missing theme.conf?)

Theme error:
no theme named 'sphinx_rtd_theme' found (missing theme.conf?)
```

https://readthedocs.org/projects/django-phonenumber-field/builds/22117691/