### PR TITLE
Add support for Django 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           - dj32
           - dj41
           - dj42
+          - dj50
         include:
           - python-version: '3.10'
             tox-environment: djmain
@@ -29,6 +30,11 @@ jobs:
             tox-environment: djmain
           - python-version: '3.12'
             tox-environment: djmain
+        exclude:
+          - python-version: '3.8'
+            tox-environment: dj50
+          - python-version: '3.9'
+            tox-environment: dj50
 
     env:
       COVERALLS_FLAG_NAME: Python ${{ matrix.python-version }} / ${{ matrix.tox-environment }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     dj32
     dj41
     dj42
+    dj50
     djmain
     mypy
 isolated_build = true
@@ -18,6 +19,7 @@ deps =
     dj32: Django>=3.2,<4.0
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
+    dj50: Django>=5.0b1,<5.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     djangorestframework
 extras = phonenumberslite


### PR DESCRIPTION
Test on this upcoming Django version. Adapted from the changes in 4752a0f4f742884307ac02b0845bc9d66a69373b.

I ran the tests with `python -Wall` and saw no new warnings.