### PR TITLE
Updated PhoneNumber.from_string() classmethod to not raise an exception if no region is specified

### DIFF
--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -42,6 +42,7 @@ class PhoneNumber(phonenumbers.PhoneNumber):
             region=region,
             keep_raw_input=True,
             numobj=phone_number_obj,
+            _check_region=bool(region),
         )
         return phone_number_obj
 


### PR DESCRIPTION
A very simple fix. PhoneNumber.from_string() allows for one to not specify the region kwarg, but the way It was interfacing with python-phonenumbers would make doing so result in an exception being thrown 100% of the time. This seems like unintended behavior, given region is not a required argument (not to mention I had a specific use case for this), so I changed it to instruct python-phonenumbers to only attempt to validate the region if one was specified, but otherwise to ignore regional validation.