### PR TITLE
Make PhoneNumberPrefixSelect use the provided region

### DIFF
--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -79,6 +79,7 @@ class PhoneNumberPrefixWidget(MultiWidget):
         country_attrs=None,
         country_choices=None,
         number_attrs=None,
+        region=None,
     ):
         """
         :keyword dict attrs: See :attr:`~django.forms.Widget.attrs`
@@ -92,9 +93,15 @@ class PhoneNumberPrefixWidget(MultiWidget):
             The second element is the label.
         :keyword dict number_attrs: The :attr:`~django.forms.Widget.attrs` for
             the local phone number :class:`~django.forms.TextInput`.
+        :keyword str region: 2-letter country code as defined in ISO 3166-1.
+            When not supplied, defaults to :setting:`PHONENUMBER_DEFAULT_REGION`
         """
         widgets = (
-            PhonePrefixSelect(initial, attrs=country_attrs, choices=country_choices),
+            PhonePrefixSelect(
+                initial or region,
+                attrs=country_attrs,
+                choices=country_choices,
+            ),
             TextInput(attrs=number_attrs),
         )
         super().__init__(widgets, attrs)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -67,6 +67,11 @@ class PhoneNumberPrefixWidgetTest(SimpleTestCase):
         self.assertIn('<option value="">---------</option>', rendered)
         self.assertIn('<option value="CN" selected>China +86</option>', rendered)
 
+    def test_uses_kwarg_region_as_prefix(self):
+        rendered = PhoneNumberPrefixWidget(region="CN").render("", "")
+        self.assertIn('<option value="">---------</option>', rendered)
+        self.assertIn('<option value="CN" selected>China +86</option>', rendered)
+
     def test_no_initial(self):
         rendered = PhoneNumberPrefixWidget().render("", "")
         self.assertIn('<option value="" selected>---------</option>', rendered)


### PR DESCRIPTION
Model fields and form fields accept a region keyword argument, and pass
it to their widget. When region is provided, initialize the country
selector in that region, chances are most users want to select it.

Fixes #574