### PR TITLE
Specify python-version for check.yml

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
+          python-version: "3.x"
           cache: pip
 
       - name: Install dependencies


### PR DESCRIPTION
Otherwise, the system version is used and the pip cache does not work.