### PR TITLE
Support Django 5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",

--- a/tests/test_formfields.py
+++ b/tests/test_formfields.py
@@ -252,7 +252,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
         form = TestForm(data={"phone_0": "", "phone_1": invalid_national_number})
         self.assertFalse(form.is_valid())
         rendered_form = form.as_ul()
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertInHTML(
                 """<ul class="errorlist" id="id_phone_error">
                 <li>This field is required.</li>
@@ -287,7 +287,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
         form = TestForm(data={"phone_0": "CA", "phone_1": ""})
         self.assertFalse(form.is_valid())
         rendered_form = form.as_ul()
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertInHTML(
                 """
                 <ul class="errorlist" id="id_phone_error">
@@ -323,7 +323,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
         form = TestForm(data={"phone_1": "654321"})
         self.assertFalse(form.is_valid())
         rendered_form = form.as_ul()
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertInHTML(
                 """
                 <ul class="errorlist" id="id_phone_error">
@@ -357,7 +357,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
         form = TestForm(data={"phone_0": "CA"})
         self.assertFalse(form.is_valid())
         rendered_form = form.as_ul()
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertInHTML(
                 """
                 <ul class="errorlist" id="id_phone_error">
@@ -395,7 +395,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
         form = TestForm(data={"phone_0": "CA", "phone_1": "0000"})
         self.assertFalse(form.is_valid())
         rendered_form = str(form)
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertInHTML(
                 """
                 <ul class="errorlist" id="id_phone_error">
@@ -530,7 +530,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
             {"name": ["Ensure this value has at least 4 characters (it has 1)."]},
         )
         form_html = form.as_p()
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertInHTML(
                 """
                 <ul class="errorlist" id="id_name_error">
@@ -609,7 +609,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
             number = SplitPhoneNumberField()
 
         form = PhoneNumberForm({"number_0": "FR", "number_1": "1"})
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertIn(
                 '<ul class="errorlist" id="id_number_error"><li>'
                 "Enter a valid phone number (e.g. 01 23 45 67 89)."
@@ -633,7 +633,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
             phone = CustomSplitPhoneNumberField()
 
         form = TestForm({"phone_0": "FR", "phone_1": "1"})
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertInHTML(
                 """
                 <ul class="errorlist" id="id_phone_error">

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -659,7 +659,7 @@ class RegionPhoneNumberModelFieldTest(TestCase):
     def test_region_field_renders_invalid_numbers(self):
         form = ARPhoneNumberForm({"phone": "abcdef"})
         self.assertFalse(form.is_valid())
-        if django.VERSION >= (6,):
+        if django.VERSION >= (5, 2):
             self.assertHTMLEqual(
                 form.as_p(),
                 '<ul class="errorlist" id="id_phone_error">'

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     dj42
     dj50
     dj51
+    dj52
     djmain
     mypy
 isolated_build = true
@@ -12,10 +13,10 @@ minversion = 1.9
 [gh]
 python =
     3.9 = dj42
-    3.10 = dj{42,50,51}
-    3.11 = dj{42,50,51}
-    3.12 = dj{42,50,51,main}
-    3.13 = dj{42,50,51,main}
+    3.10 = dj{42,50,51,52}
+    3.11 = dj{42,50,51,52}
+    3.12 = dj{42,50,51,52,main}
+    3.13 = dj{42,50,51,52,main}
     3.14 = djmain
 
 [testenv]
@@ -25,6 +26,7 @@ deps =
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0b1,<5.1
     dj51: Django>=5.1b1,<5.2
+    dj52: Django>=5.2a1,<5.3
     djmain: https://github.com/django/django/archive/main.tar.gz
     djangorestframework
 extras = phonenumberslite


### PR DESCRIPTION
Now in alpha: https://www.djangoproject.com/weblog/2025/jan/16/django-52-alpha-1-released/

Some of the test assertions changed in 9b95e59158e8c9baf64f96906787230b64407eb9 needed their version updating because they were due to changes in Django 5.2, rather than 6.0.

Other than that, no new warnings or anything to deal with.