### PR TITLE
Allow configuring empty_value for SplitPhoneNumberField

### DIFF
--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -104,7 +104,9 @@ class SplitPhoneNumberField(MultiValueField):
     default_validators = [validate_international_phonenumber]
     widget = widgets.PhoneNumberPrefixWidget
 
-    def __init__(self, *, initial=None, region=None, widget=None, **kwargs):
+    def __init__(
+        self, *, initial=None, region=None, widget=None, empty_value="", **kwargs
+    ):
         """
         :keyword list initial: A two-elements iterable:
 
@@ -122,6 +124,7 @@ class SplitPhoneNumberField(MultiValueField):
             When not supplied, defaults to :setting:`PHONENUMBER_DEFAULT_REGION`
         :keyword ~django.forms.MultiWidget widget: defaults to
             :class:`~phonenumber_field.widgets.PhoneNumberPrefixWidget`
+        :keyword empty_value: value to use when the field is empty
         """
         validate_region(region)
         region = region or getattr(settings, "PHONENUMBER_DEFAULT_REGION", None)
@@ -132,6 +135,7 @@ class SplitPhoneNumberField(MultiValueField):
         fields = (prefix_field, number_field)
         if widget is None:
             widget = self.widget((prefix_field.widget, number_field.widget))
+        self.empty_value = empty_value
         super().__init__(fields, initial=initial, widget=widget, **kwargs)
 
     def prefix_field(self):
@@ -168,7 +172,7 @@ class SplitPhoneNumberField(MultiValueField):
 
     def compress(self, data_list):
         if not data_list:
-            return data_list
+            return self.empty_value
         region, national_number = data_list
         return to_python(national_number, region=region)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -104,3 +104,7 @@ class FrenchPhoneOwner(models.Model):
 
 class TestModelRegionAR(models.Model):
     phone = PhoneNumberField(region="AR", blank=True, null=True)
+
+
+class PhoneNumberWithMaxLength(models.Model):
+    phone = PhoneNumberField(max_length=3)

--- a/tests/test_formfields.py
+++ b/tests/test_formfields.py
@@ -317,6 +317,7 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
 
         form = TestForm(data={"phone_0": "", "phone_1": ""})
         self.assertIs(form.is_valid(), True)
+        self.assertEqual(form.cleaned_data["phone"], "")
 
     def test_no_region(self):
         class TestForm(forms.Form):
@@ -389,6 +390,17 @@ class SplitPhoneNumberFormFieldTest(SimpleTestCase):
 
         form = TestForm(data={})
         self.assertIs(form.is_valid(), True)
+        self.assertEqual(form.cleaned_data["phone"], "")
+
+    def test_not_required_empty_value(self):
+        class TestForm(forms.Form):
+            phone = SplitPhoneNumberField(required=False)
+            phone_none = SplitPhoneNumberField(required=False, empty_value=None)
+
+        form = TestForm(data={})
+        self.assertIs(form.is_valid(), True)
+        self.assertEqual(form.cleaned_data["phone"], "")
+        self.assertIsNone(form.cleaned_data["phone_none"])
 
     def test_keeps_region_with_invalid_national_number(self):
         class TestForm(forms.Form):


### PR DESCRIPTION
I'm not sure at all if this my mistake or a real issue. But thought it's easiest to explain it as a PR.

Without this fix, in my django app, a string `[]` gets saved to the `phone_number` model view when nothing is entered to the form SplitPhoneNumberField. Model field is defined as:

```
    phone_number = PhoneNumberField(blank=True, null=True)
```

Field in my form:

```
    phone_number = AdminSplitPhoneNumberField(
        required=False,
        help_text='Phone number, country code separated'
    )
```

In my view I just call

```
self.form_valid(my_form)
```