### PR TITLE
Fix lost region when `PHONENUMBER_DEFAULT_FORMAT` is `NATIONAL`

### DIFF
--- a/phonenumber_field/modelfields.py
+++ b/phonenumber_field/modelfields.py
@@ -81,18 +81,16 @@ class PhoneNumberField(models.CharField):
             return [checks.Error(force_str(e), obj=self)]
         return []
 
+    def to_python(self, value):
+        return to_python(value, region=self.region)
+
     def get_prep_value(self, value):
         """
         Perform preliminary non-db specific value checks and conversions.
         """
-        if not value:
-            return super().get_prep_value(value)
-
-        if isinstance(value, PhoneNumber):
-            parsed_value = value
-        else:
-            # Convert the string to a PhoneNumber object.
-            parsed_value = to_python(value)
+        parsed_value = super().get_prep_value(value)
+        if not parsed_value:
+            return parsed_value
 
         if parsed_value.is_valid():
             # A valid phone number. Normalize it for storage.
@@ -103,7 +101,7 @@ class PhoneNumberField(models.CharField):
             # Not a valid phone number. Store the raw string.
             value = parsed_value.raw_input
 
-        return super().get_prep_value(value)
+        return value
 
     def from_db_value(self, value, expression, connection):
         return to_python(value)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -309,6 +309,22 @@ class PhoneNumberFieldAppTest(TestCase):
             transform=phone_transform,
         )
 
+    @override_settings(PHONENUMBER_DEFAULT_FORMAT="NATIONAL")
+    def test_internal_phone_when_default_format_is_national(self):
+        """Test that the region is not lost in a string conversion."""
+        tm = models.TestModel()
+        tm.phone = "+41 52 424 2424"
+        tm.full_clean()
+        tm.save()
+
+        tm = models.TestModel.objects.get(pk=tm.pk)
+        self.assertIsInstance(tm.phone, PhoneNumber)
+        self.assertQuerySetEqual(
+            models.TestModel.objects.all(),
+            [(tm.pk, "", "+41524242424")],
+            transform=phone_transform,
+        )
+
     def test_create_with_invalid_number_works(self):
         obj = models.TestModel.objects.create(phone="invalid")
         self.assertEqual(obj.phone.raw_input, "invalid")


### PR DESCRIPTION
Hi @stefanfoulis,

Thank you very much for this indispensable library :heart:

I recently noticed a bug when `PHONENUMBER_DEFAULT_FORMAT` is set to `NATIONAL`.
I initially wanted to open an issue, but when I tried to create a repro, I realized I should open a Pull Request instead.

### Description of the bug

When `PHONENUMBER_DEFAULT_FORMAT` is set to `NATIONAL`, you used to get a validation error after setting a `PhoneNumberField` to a phone number that is not in the default region.

```python
tm = models.TestModel()
tm.phone = "+41 52 424 2424"
tm.full_clean()  # raises ValidationError "The phone number entered is not valid"
```

This was because `PhoneNumberField` didn't override `to_python()`, so `CharField.to_python()` was called and returned `str(value)`.  
Since `str(value)` returns a string in the `NATIONAL` format, the region information was lost.

### Resolution

I fixed this issue by overriding `to_python()` in  `PhoneNumberField`, ensuring that a `PhoneNumber` is returned.  
This change forced me to move up the call to `super().get_prep_value()` because `CharField`'s implementation calls `self.to_python()`, which now returns a `PhoneNumber`.  
This allowed me to remove `if isinstance(value, PhoneNumber)` in `get_prep_value()` since `value` is now always a `PhoneNumber`.

Of course, I started with a unit test, which I tried to make as close as possible to the existing ones.
All tests are passing, but the `mypy` job is failing due to an internal error, which was already happening before my changes.

Please let me know if you have any questions.

Best Regards,
Benoit