### PR TITLE
Revert "Add mypy to the CI"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         tox-environment:
           - doctest
-          - mypy
           - ruff
     env:
       TOXENV: ${{ matrix.tox-environment }}

--- a/phonenumber_field/phonenumber.py
+++ b/phonenumber_field/phonenumber.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 from functools import total_ordering
-from typing import TYPE_CHECKING
 
 import phonenumbers
 from django.conf import settings
 from django.core import validators
-
-if TYPE_CHECKING:
-    # Use ‘from typing import Self’ from Python 3.11 onwards.
-    from typing_extensions import Self
 
 
 @total_ordering
@@ -28,7 +23,7 @@ class PhoneNumber(phonenumbers.PhoneNumber):
     }
 
     @classmethod
-    def from_string(cls, phone_number, region=None) -> Self:
+    def from_string(cls, phone_number, region=None):
         """
         :arg str phone_number: parse this :class:`str` as a phone number.
         :keyword str region: 2-letter country code as defined in ISO 3166-1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,21 +67,5 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.mypy]
-python_version = "3.9"
-check_untyped_defs = true
-show_error_context = true
-pretty = true
-plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
-warn_no_return = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unreachable = true
-warn_unused_configs = true
-warn_unused_ignores = true
-
-[tool.django-stubs]
-django_settings_module = "tests.settings"
-
 [tool.setuptools_scm]
 write_to = "phonenumber_field/version.py"

--- a/tests/test_formfields.py
+++ b/tests/test_formfields.py
@@ -148,7 +148,6 @@ class PhoneNumberFormFieldTest(SimpleTestCase):
 class SplitPhoneNumberFormFieldTest(SimpleTestCase):
     def example_number(self, region_code: str) -> PhoneNumber:
         number = phonenumbers.example_number(region_code)
-        assert number is not None
         e164 = phonenumbers.format_number(number, phonenumbers.PhoneNumberFormat.E164)
         return PhoneNumber.from_string(e164, region=region_code)
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     dj51
     dj52
     djmain
-    mypy
 isolated_build = true
 minversion = 1.9
 
@@ -54,16 +53,3 @@ changedir = docs/
 allowlist_externals=make
 commands =
     make doctest
-
-[testenv:mypy]
-commands =
-    mypy phonenumber_field
-    mypy tests --no-check-untyped-defs
-deps =
-    typing_extensions
-    Django
-    phonenumbers
-    djangorestframework
-    django-stubs[compatible-mypy]
-    djangorestframework-stubs
-    types-babel


### PR DESCRIPTION
This reverts commit c3a31bb793ff773800abeda99e2d886b620ac430.

Mypy itself crashes on the tip of the branch, and it provides little
value in its current state.

```
$ mypy tests --no-check-untyped-defs
/home/runner/work/django-phonenumber-field/django-phonenumber-field/.tox/mypy/lib/python3.13/site-packages/django-stubs/contrib/auth/forms.pyi:82: error: INTERNAL ERROR -- Please try using mypy master on GitHub:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
If this issue continues with mypy master, please report a bug at https://github.com/python/mypy/issues
version: 1.17.1
```

https://github.com/stefanfoulis/django-phonenumber-field/pull/567 was
offered to improve the type checking, but that PR introduces convoluted
workarounds to runtime code, for type checking usage.

We can reconsider when Django officially supports typing or when the
typing ecosystem can be used to better document and verify the code,
without requiring complex workarounds.

https://github.com/stefanfoulis/django-phonenumber-field/pull/567/files#diff-82109bfd2869a9307c952d21292dc118e522d7fb07ca87d1e607ff9b192c666fR51-R60
