### PR TITLE
Fix translations

### DIFF
--- a/phonenumber_field/locale/ar/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/ar/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Arabic locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -21,10 +21,7 @@ msgstr ""
 "X-Generator: Gtranslator 2.91.7\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -32,15 +29,13 @@ msgid ""
 msgstr "أدخل رقم هاتف صالح (مثال {example_number} ) أو رقم له بادئة دولية "
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "أدخل رقم هاتف صالح (مثال {example_number} )."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "أدخل رقم هاتف صالح (مثال {example_number} )."

--- a/phonenumber_field/locale/bg/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/bg/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# Bulgarian translations
+# Bulgarian locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Elena Rogleva <elena.rogleva@gmail.com>, 2020.
@@ -18,10 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -31,15 +28,13 @@ msgstr ""
 "с международен телефонен код."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Моля, въведете валиден телефонен номер (например {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Моля, въведете валиден телефонен номер (например {example_number})."

--- a/phonenumber_field/locale/cs/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/cs/LC_MESSAGES/django.po
@@ -13,10 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -26,15 +23,13 @@ msgstr ""
 "mezinárodní předvolbou."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vložte platné telefonní číslo (např. {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vložte platné telefonní číslo (např. {example_number})."

--- a/phonenumber_field/locale/de/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/de/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# German locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -18,10 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -31,15 +28,13 @@ msgstr ""
 "Nummer mit internationaler Vorwahl eingeben."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Bitte eine gültige Telefonnummer (z. B. {example_number}) eingeben."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Bitte eine gültige Telefonnummer (z. B. {example_number}) eingeben."

--- a/phonenumber_field/locale/eo/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/eo/LC_MESSAGES/django.po
@@ -13,10 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -26,15 +23,13 @@ msgstr ""
 "kun internacia voko-prefikso."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Bv. enigu ĝustan telefon-numeron (ekz. {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Bv. enigu ĝustan telefon-numeron (ekz. {example_number})."

--- a/phonenumber_field/locale/es/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/es/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Spanish locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -18,10 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -31,15 +28,13 @@ msgstr ""
 "con un prefijo de llamado internacional."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ingrese un número de teléfono válido  (ej.: {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ingrese un número de teléfono válido  (ej.: {example_number})."

--- a/phonenumber_field/locale/es_AR/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/es_AR/LC_MESSAGES/django.po
@@ -18,10 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -31,15 +28,13 @@ msgstr ""
 "un prefijo internacional."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ingresá un número de teléfono válido (ej.: {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ingresá un número de teléfono válido (ej.: {example_number})."

--- a/phonenumber_field/locale/fa/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/fa/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Farsi locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR mahmoodh1378@gmail.com, 2021.
@@ -17,10 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -30,15 +27,13 @@ msgstr ""
 "نظر وارد نمایید."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "یک شماره تماس معتبر وارد نمایید (مانند {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "یک شماره تماس معتبر وارد نمایید (مانند {example_number})."

--- a/phonenumber_field/locale/he/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/he/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Hebrew locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -19,30 +19,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
 "international call prefix."
 msgstr ""
-"הזן מספר טלפון חוקי (לדוגמה {example_number}) או מספר עם קידומת בינלאומית."
+"יש להזין מספר טלפון חוקי (לדוגמה {example_number}) או מספר עם קידומת "
+"בינלאומית."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
-msgstr "הזן מספר טלפון חוקי (לדוגמה {example_number})."
+msgstr "יש להזין מספר טלפון חוקי (לדוגמה {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
-msgstr "הזן מספר טלפון חוקי (לדוגמה {example_number})."
+msgstr "יש להזין מספר טלפון חוקי (לדוגמה {example_number})."
 
 #: modelfields.py:53
 msgid "Phone number"
@@ -50,8 +46,8 @@ msgstr "מספר טלפון"
 
 #: serializerfields.py:10
 msgid "Enter a valid phone number."
-msgstr "הזן מספר טלפון חוקי"
+msgstr "יש להזין מספר טלפון חוקי."
 
 #: validators.py:12 validators.py:23
 msgid "The phone number entered is not valid."
-msgstr "מספר הטלפון שהוזן אינו חוקי"
+msgstr "מספר הטלפון שהוזן אינו חוקי."

--- a/phonenumber_field/locale/hy/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/hy/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Armenian locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -19,10 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -32,15 +29,13 @@ msgstr ""
 "ձեւաչափով։"
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Մուտքագրեք վավեր հեռախոսահամար (օրինակ, {example_number})։"
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Մուտքագրեք վավեր հեռախոսահամար (օրինակ, {example_number})։"
@@ -51,7 +46,7 @@ msgstr "Հեռախոսահամար"
 
 #: serializerfields.py:10
 msgid "Enter a valid phone number."
-msgstr "Մուտքագրեք վավեր հեռախոսահամար"
+msgstr "Մուտքագրեք վավեր հեռախոսահամար։"
 
 #: validators.py:12 validators.py:23
 msgid "The phone number entered is not valid."

--- a/phonenumber_field/locale/id/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/id/LC_MESSAGES/django.po
@@ -1,3 +1,4 @@
+# Indonesian locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <arsyiaziz@gmail.com>, 2021.
@@ -17,10 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -30,15 +28,13 @@ msgstr ""
 "yang dilengkapi dengan prefiks kode panggilan internasional."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Masukkan nomor telepon yang benar (misalkan {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Masukkan nomor telepon yang benar (misalkan {example_number})."

--- a/phonenumber_field/locale/it/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/it/LC_MESSAGES/django.po
@@ -1,3 +1,4 @@
+# Italian locale.
 # Copyright (C) 2013-2018
 # This file is distributed under the same license as the PACKAGE package.
 # 
@@ -20,10 +21,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.4\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -33,15 +31,13 @@ msgstr ""
 "numero con un prefisso internazionale."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Inserisci un numero di telefono valido (esempio: {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Inserisci un numero di telefono valido (esempio: {example_number})."

--- a/phonenumber_field/locale/lt/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/lt/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# Lithuanian translations
+# Lithuanian locale.
 # Copyright (C) 2020 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
@@ -19,10 +19,7 @@ msgstr ""
 "1 : n % 1 != 0 ? 2: 3);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -32,15 +29,13 @@ msgstr ""
 "tarptautinio skambučio kodu."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Įveskite teisingą telefono numerį (pvz. {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Įveskite teisingą telefono numerį (pvz. {example_number})."

--- a/phonenumber_field/locale/nb/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/nb/LC_MESSAGES/django.po
@@ -19,10 +19,7 @@ msgstr ""
 "X-Generator: Poedit 1.8.9\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -32,15 +29,13 @@ msgstr ""
 "med internasjonal landskode."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Tast inn et gyldig telefonnummer (f.eks. {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Tast inn et gyldig telefonnummer (f.eks. {example_number})."

--- a/phonenumber_field/locale/nl/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/nl/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# Dutch Translation.
+# Dutch locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Folkert de Vries <info@fdev.nl>, 2016.
@@ -17,10 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -30,15 +27,13 @@ msgstr ""
 "telefoonnummer voorafgegaan door een landcode (bijvoorbeeld: +31)."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vul een geldig telefoonnummer in (bijvoorbeeld: {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vul een geldig telefoonnummer in (bijvoorbeeld: {example_number})."

--- a/phonenumber_field/locale/pl/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/pl/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Polish locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -19,10 +19,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -32,15 +29,13 @@ msgstr ""
 "poprzedzony międzynarodowym numerem kierunkowym."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Wprowadź poprawny numer telefonu (np. {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Wprowadź poprawny numer telefonu (np. {example_number})."

--- a/phonenumber_field/locale/pt/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/pt/LC_MESSAGES/django.po
@@ -1,3 +1,4 @@
+# Portuguese locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
@@ -18,28 +19,23 @@ msgstr ""
 "X-Generator: Lokalize 1.2\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
 "international call prefix."
 msgstr ""
 "Introduza um número de telefone válido (ex. {example_number}) ou um número "
-"com prefixo internacional"
+"com prefixo internacional."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Introduza um número de telefone válido (ex. {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Introduza um número de telefone válido (ex. {example_number})."

--- a/phonenumber_field/locale/pt_BR/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,3 +1,4 @@
+# Portuguese (Brazil) locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
@@ -18,10 +19,7 @@ msgstr ""
 "X-Generator: Lokalize 1.2\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -31,18 +29,16 @@ msgstr ""
 "número que tenha um prefixo internacional."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
-msgstr "Informe um número de telefone válido."
+msgstr "Informe um número de telefone válido, por exemplo {example_number}."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
-msgstr "Informe um número de telefone válido."
+msgstr "Informe um número de telefone válido, por exemplo {example_number}."
 
 #: modelfields.py:53
 msgid "Phone number"

--- a/phonenumber_field/locale/ru/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/ru/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Russian locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
@@ -19,10 +19,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -32,15 +29,13 @@ msgstr ""
 "префиксом международной связи."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введите корректный номер телефона (например, {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введите корректный номер телефона (например, {example_number})."

--- a/phonenumber_field/locale/sv/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/sv/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# Swedish Locale
+# Swedish Locale.
 # Copyright (C) 2017
 # This file is distributed under the same license as the django-phonenumber-field package.
 # Jonas Lidén <jonas@lideen.se>, 2017.
@@ -19,10 +19,7 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -32,15 +29,13 @@ msgstr ""
 "internationellt format."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ange ett giltigt telefonnummer (t ex {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ange ett giltigt telefonnummer (t ex {example_number})."

--- a/phonenumber_field/locale/tr/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/tr/LC_MESSAGES/django.po
@@ -18,10 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -31,15 +28,13 @@ msgstr ""
 "arama öneki olan bir numara girin."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Geçerli bir telefon numarası giriniz (ör. {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Geçerli bir telefon numarası giriniz (ör. {example_number})."

--- a/phonenumber_field/locale/uk/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/uk/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Ukrainian locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
@@ -20,10 +20,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.8\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -33,15 +30,13 @@ msgstr ""
 "префіксом міжнародного зв'язку."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введіть коректний номер телефону (наприклад, {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number (e.g. {example_number})."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введіть коректний номер телефону (наприклад, {example_number})."

--- a/phonenumber_field/locale/uk_UA/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/uk_UA/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Ukrainian locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
@@ -20,31 +20,26 @@ msgstr ""
 "X-Generator: Poedit 2.0.8\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
 "international call prefix."
 msgstr ""
-"Введіть коректний номер телефону (e.g. {example_number})  або номер "
-"зміжнародним префіксом."
+"Введіть коректний номер телефону (наприклад, {example_number}) або номер з "
+"префіксом міжнародного зв'язку."
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
-msgstr "Введіть коректний номер телефону."
+msgstr "Введіть коректний номер телефону (наприклад, {example_number})."
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
-msgstr "Введіть коректний номер телефону."
+msgstr "Введіть коректний номер телефону (наприклад, {example_number})."
 
 #: modelfields.py:53
 msgid "Phone number"

--- a/phonenumber_field/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# Simplified Chinese locale.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -19,10 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: formfields.py:57
-#, fuzzy, python-brace-format
-#| msgid ""
-#| "Enter a valid phone number (e.g. {example_number}) or a number with an "
-#| "international call prefix."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
 "Enter a valid phone number (e.g. {example_number}) or a number with an "
@@ -30,15 +27,13 @@ msgid ""
 msgstr "输入一个合法的电话号码（例如，{example_number}）或带国际冠码的号码。"
 
 #: formfields.py:64
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number."
+#, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "输入一个合法的电话号码（例如，{example_number}）。"
 
 #: formfields.py:157
-#, fuzzy, python-brace-format
-#| msgid "Enter a valid phone number."
+#, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "输入一个合法的电话号码（例如，{example_number}）。"


### PR DESCRIPTION
Commit 7a0b5b0 (“Clarify translation context for error messages”) in July 2024 broke the localization of phonenumber-field by marking the translation strings fuzzy. This PR fixes the locale files which have up-to-date translations.

The following locale files are outdated and need to be revised by a speaker of the relevant language (including resolving the fuzziness):

- az
- bn
- da
- fi
- ko
- ro
- sk
