### PR TITLE
Add Hungarian locale

### DIFF
--- a/phonenumber_field/locale/hu/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/hu/LC_MESSAGES/django.po
@@ -1,0 +1,47 @@
+# This file is distributed under the same license as the PACKAGE package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: formfields.py:57
+msgctxt "{example_number} is a national phone number."
+msgid ""
+"Enter a valid phone number (e.g. {example_number}) or a number with an "
+"international call prefix."
+msgstr ""
+"Kérem adjon meg egy helyes (pl {example_number}), vagy egy nemzetközi "
+"előhívóval rendelkező telefonszámot."
+
+#: formfields.py:64
+#, python-brace-format
+msgctxt "{example_number} is an international phone number."
+msgid "Enter a valid phone number (e.g. {example_number})."
+msgstr "Kérem adjon meg egy valós (pl {example_number}) telefonszámot."
+
+#: formfields.py:157
+msgctxt "{example_number} is a national phone number."
+msgid "Enter a valid phone number (e.g. {example_number})."
+msgstr "Kérem adjon meg egy valós (pl {example_number}) telefonszámot."
+
+#: modelfields.py:53
+msgid "Phone number"
+msgstr "Telefonszám"
+
+#: serializerfields.py:10
+msgid "Enter a valid phone number."
+msgstr "Kérem adjon meg egy valós telefonszámot."
+
+#: validators.py:12 validators.py:23
+msgid "The phone number entered is not valid."
+msgstr "A megadott telefonszám nem valós."


### PR DESCRIPTION
- Remove fuzzy markers from de locale messages for national/international phone number validation in form fields.
- Refine German translations for phone number input prompts to include international prefix examples.
- Introduce new hu locale django.po with translations for form fields, model fields, serializer fields, and validators for phone numbers.