### PR TITLE
translations: Remove line location from messages files

### DIFF
--- a/phonenumber_field/locale/ar/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2020-03-23 15:41+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgid ""
 "international call prefix."
 msgstr "أدخل رقم هاتف صالح (مثال {example_number} ) أو رقم له بادئة دولية "
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "أدخل رقم هاتف صالح (مثال {example_number} )."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "أدخل رقم هاتف صالح (مثال {example_number} )."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "رقم الهاتف"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "أدخل رقم هاتف صالح"
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "رقم الهاتف الذي تم إدخاله غير صالح."

--- a/phonenumber_field/locale/az/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/az/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Emin Mastizada <emin@linux.com>\n"
 "Language-Team: Azerbaijani <info@mozillaz.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
@@ -26,28 +26,28 @@ msgid ""
 "international call prefix."
 msgstr "Düzgün telefon nömrəsi daxil edin."
 
-#: formfields.py:64
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Düzgün telefon nömrəsi daxil edin."
 
-#: formfields.py:157
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Düzgün telefon nömrəsi daxil edin."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefon nömrəsi"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Düzgün telefon nömrəsi daxil edin."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Daxil etdiyiniz telefon nömrəsi səhvdir."

--- a/phonenumber_field/locale/bg/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/bg/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2020-11-12 13:04+0200\n"
 "Last-Translator: ELENA ROGLEVA <elena.rogleva@gmail.com>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -27,26 +27,26 @@ msgstr ""
 "Моля, въведете валиден телефонен номер (например {example_number}) или номер "
 "с международен телефонен код."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Моля, въведете валиден телефонен номер (например {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Моля, въведете валиден телефонен номер (например {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Телефонен номер"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Моля, въведете валиден телефонен номер."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Въведеният телефонен номер е невалиден."

--- a/phonenumber_field/locale/bn/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/bn/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Tanvir Hasan <tanvir002700@gmail.com>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
@@ -26,28 +26,28 @@ msgid ""
 "international call prefix."
 msgstr "একটি বৈধ ফোন নম্বর লিখুন।"
 
-#: formfields.py:64
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "একটি বৈধ ফোন নম্বর লিখুন।"
 
-#: formfields.py:157
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "একটি বৈধ ফোন নম্বর লিখুন।"
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "ফোন নাম্বার"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "একটি বৈধ ফোন নম্বর লিখুন।"
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "প্রদত্ত ফোন নাম্বারটি বৈধ নয়।"

--- a/phonenumber_field/locale/cs/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/cs/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: django-phonenumber-field 5.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2021-07-28 21:06+0200\n"
 "Last-Translator: melanger\n"
 "Language-Team: Melanger.cz\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -22,26 +22,26 @@ msgstr ""
 "Vložte platné telefonní číslo (např. {example_number}) nebo číslo s "
 "mezinárodní předvolbou."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vložte platné telefonní číslo (např. {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vložte platné telefonní číslo (např. {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefonní číslo"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Vložte platné telefonní číslo."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Zadané telefonní číslo není platné."

--- a/phonenumber_field/locale/da/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/da/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2016-03-14 12:50+0100\n"
 "Last-Translator: René Tronsgaard <tronsgaard@gmail.com>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: formfields.py:57
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
@@ -26,28 +26,28 @@ msgid ""
 "international call prefix."
 msgstr "Indtast et gyldigt telefonnummer."
 
-#: formfields.py:64
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Indtast et gyldigt telefonnummer."
 
-#: formfields.py:157
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Indtast et gyldigt telefonnummer."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Indtast et gyldigt telefonnummer."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Det indtastede telefonnummer er ugyldigt."

--- a/phonenumber_field/locale/de/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -27,26 +27,26 @@ msgstr ""
 "Bitte eine gültige Telefonnummer (z. B. {example_number}) oder eine gültige "
 "Nummer mit internationaler Vorwahl eingeben."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Bitte eine gültige Telefonnummer (z. B. {example_number}) eingeben."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Bitte eine gültige Telefonnummer (z. B. {example_number}) eingeben."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Bitte eine gültige Telefonnummer eingeben."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Die eingegebene Telefonnummer ist ungültig."

--- a/phonenumber_field/locale/eo/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/eo/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2021-03-11 16:09+0000\n"
 "Last-Translator: Meiyer <interDist@users.noreply.github.com>\n"
 "Language-Team: Esperanto\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -22,26 +22,26 @@ msgstr ""
 "Bv. enigu ĝustan lokan telefon-numeron (ekz. {example_number}) aŭ numeron "
 "kun internacia voko-prefikso."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Bv. enigu ĝustan telefon-numeron (ekz. {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Bv. enigu ĝustan telefon-numeron (ekz. {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefona numero"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Bv. enigu ĝustan telefon-numeron."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "La provizita numero ne estas en akceptebla formato."

--- a/phonenumber_field/locale/es/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2020-09-30 18:32+0200\n"
 "Last-Translator: Joao Lopez <jslopez@csrg.inf.utfsm.cl>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -27,26 +27,26 @@ msgstr ""
 "Ingrese un número de teléfono válido  (ej.: {example_number}) o un número "
 "con un prefijo de llamado internacional."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ingrese un número de teléfono válido  (ej.: {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ingrese un número de teléfono válido  (ej.: {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Número de teléfono"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Ingrese un número de teléfono válido."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "El número de teléfono ingresado no es válido."

--- a/phonenumber_field/locale/es_AR/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/es_AR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -27,26 +27,26 @@ msgstr ""
 "Ingresá un número de teléfono válido (ej.: {example_number}) o un número con "
 "un prefijo internacional."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ingresá un número de teléfono válido (ej.: {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ingresá un número de teléfono válido (ej.: {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Número de teléfono"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Ingresá un número de teléfono válido."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "El número de teléfono ingresado es inválido."

--- a/phonenumber_field/locale/fa/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/fa/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2021-12-10 14:27+0330\n"
 "Last-Translator: Mahmood Heidari mahmoodh1378@gmail.com\n"
 "Language-Team: \n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -26,26 +26,26 @@ msgstr ""
 "یک شماره تماس معتبر (مانند {example_number}) یا یک شماره با پیشوند کشور مورد "
 "نظر وارد نمایید."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "یک شماره تماس معتبر وارد نمایید (مانند {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "یک شماره تماس معتبر وارد نمایید (مانند {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "شماره تماس"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "یک شماره تماس معتبر وارد نمایید."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "شماره تماس وارد شده معتبر نیست."

--- a/phonenumber_field/locale/fi/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2015-10-26 10:25+0200\n"
 "Last-Translator: Ville Skyttä <ville.skytta@iki.fi>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.5\n"
 
-#: formfields.py:57
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
@@ -26,28 +26,28 @@ msgid ""
 "international call prefix."
 msgstr "Syötä oikea puhelinnumero."
 
-#: formfields.py:64
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Syötä oikea puhelinnumero."
 
-#: formfields.py:157
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Syötä oikea puhelinnumero."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Puhelinnumero"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Syötä oikea puhelinnumero."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Syötetty puhelinnumero on virheellinen."

--- a/phonenumber_field/locale/fr/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2024-07-16 11:23+0200\n"
 "Last-Translator: François Freitag <mail@franek.fr>\n"
 "Language-Team: French <gmludo@gmail.com>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Saisissez un numéro de téléphone valide, par exemple {example_number}, ou un "
 "numéro avec un indicatif international."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Saisissez un numéro de téléphone valide, par exemple {example_number}."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Saisissez un numéro de téléphone valide, par exemple {example_number}."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Numéro de téléphone"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Saisissez un numéro de téléphone valide."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Le numéro saisi n'est pas valide."

--- a/phonenumber_field/locale/he/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/he/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "יש להזין מספר טלפון חוקי (לדוגמה {example_number}) או מספר עם קידומת "
 "בינלאומית."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "יש להזין מספר טלפון חוקי (לדוגמה {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "יש להזין מספר טלפון חוקי (לדוגמה {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "מספר טלפון"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "יש להזין מספר טלפון חוקי."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "מספר הטלפון שהוזן אינו חוקי."

--- a/phonenumber_field/locale/hy/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/hy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Arnak Melikyan <arnak@melikyan.am>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Մուտքագրեք վավեր հեռախոսահամար (օրինակ, {example_number}) կամ միջազգային "
 "ձեւաչափով։"
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Մուտքագրեք վավեր հեռախոսահամար (օրինակ, {example_number})։"
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Մուտքագրեք վավեր հեռախոսահամար (օրինակ, {example_number})։"
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Հեռախոսահամար"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Մուտքագրեք վավեր հեռախոսահամար։"
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Մուտքագրված հեռախոսահամարը վավեր չէ։"

--- a/phonenumber_field/locale/id/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/id/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2021-02-05 21:42+0700\n"
 "Last-Translator: Arsyi Syarief Aziz <arsyiaziz@gmail.com>\n"
 "Language-Team: Indonesian <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -27,26 +27,26 @@ msgstr ""
 "Masukkan nomor telepon yang benar (misalkan {example_number}) atau nomor "
 "yang dilengkapi dengan prefiks kode panggilan internasional."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Masukkan nomor telepon yang benar (misalkan {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Masukkan nomor telepon yang benar (misalkan {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Nomor telepon"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Masukkan nomor telepon yang benar."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Nomor telepon yang dimasukkan tidak benar."

--- a/phonenumber_field/locale/it/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/it/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # Italian locale.
 # Copyright (C) 2013-2018
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Francesco Facconi <francesco@immediatic.it>, 2013-2017.
 # Paolo Melchiorre <paolo@melchiorre.org>, 2018.
 # Ruggero Fabbiano <ruggero_fabbiano@outlook.com>, 2023.
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2018-02-28 20:23+0100\n"
 "Last-Translator: Paolo Melchiorre <paolo@melchiorre.org>\n"
 "Language-Team: Italian <paolo@melchiorre.org>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.4\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -30,26 +30,26 @@ msgstr ""
 "Inserisci un numero di telefono valido (esempio: {example_number}) o un "
 "numero con un prefisso internazionale."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Inserisci un numero di telefono valido (esempio: {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Inserisci un numero di telefono valido (esempio: {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Numero di telefono"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Inserisci un numero di telefono valido."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Il numero di telefono inserito non è valido."

--- a/phonenumber_field/locale/ko/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/ko/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2017-04-15 16:56+0100\n"
 "Last-Translator: Jiyoon Ha <cryptography@konkuk.ac.kr>\n"
 "Language-Team: \n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: formfields.py:57
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
@@ -25,28 +25,28 @@ msgid ""
 "international call prefix."
 msgstr "올바른 전화번호를 입력해주세요."
 
-#: formfields.py:64
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "올바른 전화번호를 입력해주세요."
 
-#: formfields.py:157
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "올바른 전화번호를 입력해주세요."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "전화번호"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "올바른 전화번호를 입력해주세요."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "입력하신 전화번호가 올바른 형식이 아닙니다."

--- a/phonenumber_field/locale/lt/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/lt/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2020-10-15 21:22+0300\n"
 "Last-Translator: KiraLT <info@kiralt.dev>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/django/django)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
 "1 : n % 1 != 0 ? 2: 3);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Įveskite teisingą telefono numerį (pvz. {example_number}) arba numerį su "
 "tarptautinio skambučio kodu."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Įveskite teisingą telefono numerį (pvz. {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Įveskite teisingą telefono numerį (pvz. {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefono numeris"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Įveskite teisingą telefono numerį."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Įvestas telefono numeris nėra teisingas."

--- a/phonenumber_field/locale/nb/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/nb/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2016-10-21 15:04+0200\n"
 "Last-Translator: Kristian Klette <klette@klette.us>\n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.9\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Tast inn et gyldig telefonnummer (f.eks. {example_number}) eller et nummer "
 "med internasjonal landskode."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Tast inn et gyldig telefonnummer (f.eks. {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Tast inn et gyldig telefonnummer (f.eks. {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Tast inn et gyldig telefonnummer."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Telefonnummeret er ugyldig."

--- a/phonenumber_field/locale/nl/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/nl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Folkert de Vries <info@fdev.nl>\n"
 "Language: nl\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -26,26 +26,26 @@ msgstr ""
 "Vul een geldig telefoonnummer in (bijvoorbeeld: {example_number}) of een "
 "telefoonnummer voorafgegaan door een landcode (bijvoorbeeld: +31)."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vul een geldig telefoonnummer in (bijvoorbeeld: {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vul een geldig telefoonnummer in (bijvoorbeeld: {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefoonnummer"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Vul een geldig telefoonnummer in."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Het ingevulde telefoonnummer is niet geldig."

--- a/phonenumber_field/locale/pl/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2022-03-22 08:45+0100\n"
 "Last-Translator: Andrzej Mateja <mateja.and@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Wprowadź poprawny numer telefonu (np. {example_number}) lub numer "
 "poprzedzony międzynarodowym numerem kierunkowym."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Wprowadź poprawny numer telefonu (np. {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Wprowadź poprawny numer telefonu (np. {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Numer telefonu"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Wprowadź poprawny numer telefonu."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Wprowadzony numer telefonu jest nieprawidłowy."

--- a/phonenumber_field/locale/pt/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2013-02-26 14:10+0200\n"
 "Last-Translator: Luis Rodrigues <lfrodrigues@gmail.com>\n"
 "Language-Team: Portuguese <lfrodrigues@gmail.com>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "X-Generator: Lokalize 1.2\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Introduza um número de telefone válido (ex. {example_number}) ou um número "
 "com prefixo internacional."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Introduza um número de telefone válido (ex. {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Introduza um número de telefone válido (ex. {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Número de telefone"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Introduza um número de telefone válido."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Este número de telefone não é válido."

--- a/phonenumber_field/locale/pt_BR/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/pt_BR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2013-02-26 14:10-0300\n"
 "Last-Translator: Fábio Thomaz <fabio_thz@yahoo.com.br>\n"
 "Language-Team: Portuguese - Brazil <fabio_thz@yahoo.com.br>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "X-Generator: Lokalize 1.2\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Forneça um número de telefone válido, por exemplo {example_number}, ou um "
 "número que tenha um prefixo internacional."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Informe um número de telefone válido, por exemplo {example_number}."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Informe um número de telefone válido, por exemplo {example_number}."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Número de telefone"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Informe um número de telefone válido."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Este número de telefone não é válido."

--- a/phonenumber_field/locale/ro/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/ro/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2018-10-19 14:07+0300\n"
 "Last-Translator: Cristi Vîjdea <cristi@cvjd.me>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
 "2:1));\n"
 
-#: formfields.py:57
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
@@ -26,28 +26,28 @@ msgid ""
 "international call prefix."
 msgstr "Introduceți un număr de telefon valid."
 
-#: formfields.py:64
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Introduceți un număr de telefon valid."
 
-#: formfields.py:157
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Introduceți un număr de telefon valid."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Număr de telefon"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Introduceți un număr de telefon valid."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Numărul de telefon introdus nu este valid."

--- a/phonenumber_field/locale/ru/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/ru/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2021-05-15 19:57+0700\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Введите корректный номер телефона (например, {example_number}) или номер с "
 "префиксом международной связи."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введите корректный номер телефона (например, {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введите корректный номер телефона (например, {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Номер телефона"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Введите корректный номер телефона."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Введен некорректный номер телефона."

--- a/phonenumber_field/locale/sk/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/sk/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: formfields.py:57
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
@@ -26,28 +26,28 @@ msgid ""
 "international call prefix."
 msgstr "Vložte platné telefónne číslo."
 
-#: formfields.py:64
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vložte platné telefónne číslo."
 
-#: formfields.py:157
+#: formfields.py
 #, fuzzy, python-brace-format
 #| msgid "Enter a valid phone number."
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Vložte platné telefónne číslo."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefónne číslo"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Vložte platné telefónne číslo."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Zadané telefónne číslo je neplatné."

--- a/phonenumber_field/locale/sv/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/sv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2017-12-05 22:18+0100\n"
 "Last-Translator: Jonas Lidén <jonas@lideen.se>\n"
 "Language-Team: Swedish\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -28,26 +28,26 @@ msgstr ""
 "Ange ett giltigt telefonnummer (t ex {example_number}) eller ett nummer med "
 "internationellt format."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ange ett giltigt telefonnummer (t ex {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Ange ett giltigt telefonnummer (t ex {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Ange ett giltigt telefonnummer."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Det angivna telefonnumret är inte giltigt."

--- a/phonenumber_field/locale/tr/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/tr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2022-01-15 14:51+0300\n"
 "Last-Translator: Şuayip Üzülmez <suayip.541@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -27,26 +27,26 @@ msgstr ""
 "Geçerli bir telefon numarası girin (ör. {example_number}) ya da uluslararası "
 "arama öneki olan bir numara girin."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Geçerli bir telefon numarası giriniz (ör. {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Geçerli bir telefon numarası giriniz (ör. {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Telefon numarası"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Geçerli bir telefon numarası giriniz."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Girmiş olduğunuz telefon numarası geçersiz."

--- a/phonenumber_field/locale/uk/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/uk/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2018-06-06 00:07+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,7 +19,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.0.8\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -29,26 +29,26 @@ msgstr ""
 "Введіть коректний номер телефону (наприклад, {example_number}) або номер з "
 "префіксом міжнародного зв'язку."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введіть коректний номер телефону (наприклад, {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введіть коректний номер телефону (наприклад, {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Номер телефону"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Введіть коректний номер телефону."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Введено некоректний номер телефону."

--- a/phonenumber_field/locale/uk_UA/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/uk_UA/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: 2018-06-06 00:07+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,7 +19,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.0.8\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -29,26 +29,26 @@ msgstr ""
 "Введіть коректний номер телефону (наприклад, {example_number}) або номер з "
 "префіксом міжнародного зв'язку."
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введіть коректний номер телефону (наприклад, {example_number})."
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "Введіть коректний номер телефону (наприклад, {example_number})."
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "Номер телефону"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "Введіть коректний номер телефону."
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "Введено некоректний номер телефону."

--- a/phonenumber_field/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/phonenumber_field/locale/zh_Hans/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:14+0200\n"
+"POT-Creation-Date: 2025-10-01 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Wentao Han <wentao.han@gmail.com>\n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: formfields.py:57
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid ""
@@ -26,26 +26,26 @@ msgid ""
 "international call prefix."
 msgstr "输入一个合法的电话号码（例如，{example_number}）或带国际冠码的号码。"
 
-#: formfields.py:64
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is an international phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "输入一个合法的电话号码（例如，{example_number}）。"
 
-#: formfields.py:157
+#: formfields.py
 #, python-brace-format
 msgctxt "{example_number} is a national phone number."
 msgid "Enter a valid phone number (e.g. {example_number})."
 msgstr "输入一个合法的电话号码（例如，{example_number}）。"
 
-#: modelfields.py:53
+#: modelfields.py
 msgid "Phone number"
 msgstr "电话号码"
 
-#: serializerfields.py:10
+#: serializerfields.py
 msgid "Enter a valid phone number."
 msgstr "输入一个合法的电话号码。"
 
-#: validators.py:12 validators.py:23
+#: validators.py
 msgid "The phone number entered is not valid."
 msgstr "输入的电话号码不合法。"


### PR DESCRIPTION
The lines can easily change with code change, which requires updating the messages file frequently.

Keep the file as a pointer to help technical-savvy translators find the message context, but without a line number. They’ll be able to search within the file easily.

Messages were collected with:
```
django-admin makemessages --all --add-location=file
```

Recommended-by: https://github.com/stefanfoulis/django-phonenumber-field/pull/643#issuecomment-3356540061