### PR TITLE
Handle empty values in SplitPhoneNumberField with max_length

### DIFF
--- a/phonenumber_field/formfields.py
+++ b/phonenumber_field/formfields.py
@@ -203,7 +203,7 @@ class SplitPhoneNumberField(MultiValueField):
                         example_number=example_number,
                     )
         clean_value = super().clean(value)
-        if self.max_length is not None:
+        if clean_value not in self.empty_values and self.max_length is not None:
             phonenumber_str = clean_value.format_as(
                 getattr(settings, "PHONENUMBER_DB_FORMAT", "E164")
             )

--- a/tests/models.py
+++ b/tests/models.py
@@ -106,5 +106,9 @@ class TestModelRegionAR(models.Model):
     phone = PhoneNumberField(region="AR", blank=True, null=True)
 
 
-class PhoneNumberWithMaxLength(models.Model):
-    phone = PhoneNumberField(max_length=3)
+class PhoneNumberWithMaxLengthDefault(models.Model):
+    phone = PhoneNumberField(max_length=12, blank=True, default="")
+
+
+class PhoneNumberWithMaxLengthNullable(models.Model):
+    phone = PhoneNumberField(max_length=12, blank=True, null=True)


### PR DESCRIPTION
Would crash because `format_as` is only available on PhoneNumber subclasses.