### PR TITLE
Replace example tox command with a link to the official cheat sheet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,5 @@ available Python interpreters and generate a combined coverage report::
 
     tox
 
-run a specific combination::
-
-    tox -e py310-djmain,py39-djmain
+The `cheat sheet for tox <https://tox.wiki/en/latest/user_guide.html#cli>`__
+gives the most useful commands.


### PR DESCRIPTION
Each environment contain the version number (django, python), which get
bumped once in a while, but the command in the README isn’t updated to
match these versions, and becomes invalid.

Tox has a cheat sheet explaining the most useful commands.
