### PR TITLE
Use stable readthedocs OS and python versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,9 +2,9 @@
 version: 2
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.13"
+    python: latest
 
 python:
   install:


### PR DESCRIPTION
Instead of pinning to a specific version (and forgetting to bump it),
just use the latest available.
