### PR TITLE
Use the organisation repository

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 **Note:** Releases are now tracked using
-`GitHub releases <https://github.com/stefanfoulis/django-phonenumber-field/releases>`__.
+`GitHub releases <https://github.com/django-phonenumber-field/django-phonenumber-field/releases>`__.
 This document remains for historical purposes.
 
 6.1.0 (2022-01-12)

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,10 @@
 django-phonenumber-field
 ========================
 
-.. image:: https://github.com/stefanfoulis/django-phonenumber-field/workflows/Test/badge.svg
-    :target: https://github.com/stefanfoulis/django-phonenumber-field/workflows/Test/badge.svg
-.. image:: https://img.shields.io/coveralls/stefanfoulis/django-phonenumber-field/develop.svg
-    :target: https://coveralls.io/github/stefanfoulis/django-phonenumber-field?branch=main
+.. image:: https://github.com/django-phonenumber-field/django-phonenumber-field/workflows/Test/badge.svg
+    :target: https://github.com/django-phonenumber-field/django-phonenumber-field/workflows/Test/badge.svg
+.. image:: https://img.shields.io/coveralls/django-phonenumber-field/django-phonenumber-field/develop.svg
+    :target: https://coveralls.io/github/django-phonenumber-field/django-phonenumber-field?branch=main
 
 A Django library which interfaces with `python-phonenumbers`_ to validate, pretty print and convert
 phone numbers. ``python-phonenumbers`` is a port of Google's `libphonenumber`_ library, which

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,11 @@ phonenumbers = ["phonenumbers >= 7.0.2"]
 phonenumberslite = ["phonenumberslite >= 7.0.2"]
 
 [project.urls]
-Homepage = "https://github.com/stefanfoulis/django-phonenumber-field"
+Homepage = "https://github.com/django-phonenumber-field/django-phonenumber-field"
 Documentation = "https://django-phonenumber-field.readthedocs.io/"
-Source = "https://github.com/stefanfoulis/django-phonenumber-field"
-Tracker = "https://github.com/stefanfoulis/django-phonenumber-field/issues/"
-Changelog = "https://github.com/stefanfoulis/django-phonenumber-field/releases/"
+Source = "https://github.com/django-phonenumber-field/django-phonenumber-field"
+Tracker = "https://github.com/django-phonenumber-field/django-phonenumber-field/issues/"
+Changelog = "https://github.com/django-phonenumber-field/django-phonenumber-field/releases/"
 
 [tool.ruff.lint]
 # see prefixes in https://beta.ruff.rs/docs/rules/


### PR DESCRIPTION
Moved the project from its original author repository to an organization to share the maintenance (in particular, access to the repository settings).