### PR TITLE
Make babel an optional-dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = ["version"]
 dependencies = ["Django>=4.2"]
 
 [project.optional-dependencies]
+babel = ["Babel"]
 phonenumbers = ["phonenumbers >= 7.0.2"]
 phonenumberslite = ["phonenumberslite >= 7.0.2"]
 


### PR DESCRIPTION
Was previously only mentioned in the docs. Users may want to better document their requirements through `django-phonenumber-field[babel]` instead of requiring Babel separately.

Closes #668 