### PR TITLE
Change Jeff Bowen's email to GitHub noreply

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,7 +31,7 @@ hwkns <danieldhawkins@gmail.com>
 Illya <imadnix@gmail.com>
 ILUXONCHIK <iluxon4ik@hotmail.com>
 Jacob Rief <jacob.rief@gmail.com>
-Jeff Bowen <jeff.d.bowen@gmail.com>
+Jeff Bowen <272795+jeffbowen@users.noreply.github.com>
 jendas1 <jendas1@yahoo.com>
 Joao S. López <jslopez@csrg.inf.utfsm.cl>
 John Vandenberg <jayvdb@gmail.com>


### PR DESCRIPTION
Updated Jeff Bowen's email address to a GitHub noreply address.